### PR TITLE
OXLA-8189 Implement `Non-optimizing Reference Engine Construction (NoREC)` oracle

### DIFF
--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -18,8 +18,10 @@ public class OxlaCommon {
             "invalid JOIN ON clause condition. Only equi join is supported"
     );
     public static final List<String> GROUP_BY_ERRORS = List.of(
-            "non-integer constant in GROUP BY",
-            "is not in select list"
+            "non-integer constant in GROUP BY"
+    );
+    public static final List<Pattern> GROUP_BY_REGEX_ERRORS = List.of(
+            Pattern.compile("GROUP BY position (\\d+) is not in select list")
     );
     public static final List<String> ORDER_BY_ERRORS = List.of(
             "non-integer constant in ORDER BY"

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -1,0 +1,22 @@
+package sqlancer.oxla;
+
+import java.util.List;
+
+public class OxlaCommon {
+    private OxlaCommon() {
+    }
+
+    public static List<String> SYNTAX_ERRORS = List.of(
+            "invalid input syntax for type"
+    );
+    public static final List<String> JOIN_ERRORS = List.of(
+            "invalid JOIN ON clause condition. Only equi join is supported"
+    );
+    public static final List<String> GROUP_BY_ERRORS = List.of(
+            "non-integer constant in GROUP BY",
+            "is not in select list"
+    );
+    public static final List<String> ORDER_BY_ERRORS = List.of(
+            "non-integer constant in ORDER BY"
+    );
+}

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -11,7 +11,8 @@ public class OxlaCommon {
             "invalid input syntax for type"
     );
     public static final List<Pattern> SYNTAX_REGEX_ERRORS = List.of(
-            Pattern.compile("operator \"[^\"]+\" is not unique")
+            Pattern.compile("operator \"[^\"]+\" is not unique"),
+            Pattern.compile("operator is not unique: (.*)")
     );
     public static final List<String> JOIN_ERRORS = List.of(
             "invalid JOIN ON clause condition. Only equi join is supported"

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -1,13 +1,17 @@
 package sqlancer.oxla;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class OxlaCommon {
     private OxlaCommon() {
     }
 
-    public static List<String> SYNTAX_ERRORS = List.of(
+    public static final List<String> SYNTAX_ERRORS = List.of(
             "invalid input syntax for type"
+    );
+    public static final List<Pattern> SYNTAX_REGEX_ERRORS = List.of(
+            Pattern.compile("operator \"[^\"]+\" is not unique")
     );
     public static final List<String> JOIN_ERRORS = List.of(
             "invalid JOIN ON clause condition. Only equi join is supported"

--- a/src/sqlancer/oxla/OxlaOracleFactory.java
+++ b/src/sqlancer/oxla/OxlaOracleFactory.java
@@ -18,6 +18,7 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
             OxlaExpressionGenerator generator = new OxlaExpressionGenerator(globalState);
             ExpectedErrors errors = ExpectedErrors.newErrors()
                     .with(OxlaCommon.SYNTAX_ERRORS)
+                    .withRegex(OxlaCommon.SYNTAX_REGEX_ERRORS)
                     .with(OxlaCommon.JOIN_ERRORS)
                     .with(OxlaCommon.GROUP_BY_ERRORS)
                     .with(OxlaCommon.ORDER_BY_ERRORS)

--- a/src/sqlancer/oxla/OxlaOracleFactory.java
+++ b/src/sqlancer/oxla/OxlaOracleFactory.java
@@ -16,7 +16,12 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
         @Override
         public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
             OxlaExpressionGenerator generator = new OxlaExpressionGenerator(globalState);
-            ExpectedErrors errors = new ExpectedErrors(); // TODO: Errors.
+            ExpectedErrors errors = ExpectedErrors.newErrors()
+                    .with(OxlaCommon.SYNTAX_ERRORS)
+                    .with(OxlaCommon.JOIN_ERRORS)
+                    .with(OxlaCommon.GROUP_BY_ERRORS)
+                    .with(OxlaCommon.ORDER_BY_ERRORS)
+                    .build();
             return new NoRECOracle<>(globalState, generator, errors);
         }
     },

--- a/src/sqlancer/oxla/OxlaOracleFactory.java
+++ b/src/sqlancer/oxla/OxlaOracleFactory.java
@@ -21,6 +21,7 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
                     .withRegex(OxlaCommon.SYNTAX_REGEX_ERRORS)
                     .with(OxlaCommon.JOIN_ERRORS)
                     .with(OxlaCommon.GROUP_BY_ERRORS)
+                    .withRegex(OxlaCommon.GROUP_BY_REGEX_ERRORS)
                     .with(OxlaCommon.ORDER_BY_ERRORS)
                     .build();
             return new NoRECOracle<>(globalState, generator, errors);

--- a/src/sqlancer/oxla/OxlaOracleFactory.java
+++ b/src/sqlancer/oxla/OxlaOracleFactory.java
@@ -2,7 +2,10 @@ package sqlancer.oxla;
 
 import sqlancer.OracleFactory;
 import sqlancer.common.oracle.CompositeTestOracle;
+import sqlancer.common.oracle.NoRECOracle;
 import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.oxla.gen.OxlaExpressionGenerator;
 import sqlancer.oxla.oracle.OxlaFuzzer;
 
 import java.util.ArrayList;
@@ -12,7 +15,9 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
     NOREC {
         @Override
         public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
-            return null;
+            OxlaExpressionGenerator generator = new OxlaExpressionGenerator(globalState);
+            ExpectedErrors errors = new ExpectedErrors(); // TODO: Errors.
+            return new NoRECOracle<>(globalState, generator, errors);
         }
     },
     QUERY_PARTITIONING {

--- a/src/sqlancer/oxla/OxlaToStringVisitor.java
+++ b/src/sqlancer/oxla/OxlaToStringVisitor.java
@@ -1,10 +1,8 @@
 package sqlancer.oxla;
 
+import sqlancer.Randomly;
 import sqlancer.common.ast.newast.NewToStringVisitor;
-import sqlancer.oxla.ast.OxlaConstant;
-import sqlancer.oxla.ast.OxlaExpression;
-import sqlancer.oxla.ast.OxlaJoin;
-import sqlancer.oxla.ast.OxlaSelect;
+import sqlancer.oxla.ast.*;
 
 public class OxlaToStringVisitor extends NewToStringVisitor<OxlaExpression> {
     private static final OxlaToStringVisitor visitor = new OxlaToStringVisitor();
@@ -29,6 +27,8 @@ public class OxlaToStringVisitor extends NewToStringVisitor<OxlaExpression> {
             visit((OxlaSelect) expr);
         } else if (expr instanceof OxlaJoin) {
             visit((OxlaJoin) expr);
+        } else if (expr instanceof OxlaCast) {
+            visit((OxlaCast) expr);
         } else {
             throw new AssertionError(expr.getClass());
         }
@@ -82,10 +82,27 @@ public class OxlaToStringVisitor extends NewToStringVisitor<OxlaExpression> {
     }
 
     private void visit(OxlaJoin join) {
+        visit(join.leftTable);
         sb.append(String.format(" %s JOIN ", join.type));
+        visit(join.rightTable);
         if (join.onClause != null) {
             sb.append(" ON ");
             visit(join.onClause);
+        }
+    }
+
+    private void visit(OxlaCast cast) {
+        if (Randomly.getBoolean()) {
+            sb.append("CAST(");
+            visit(cast.expression);
+            sb.append(" AS ");
+            sb.append(cast.dataType.toString());
+            sb.append(")");
+        } else {
+            sb.append("(");
+            visit(cast.expression);
+            sb.append(")::");
+            sb.append(cast.dataType.toString());
         }
     }
 }

--- a/src/sqlancer/oxla/OxlaToStringVisitor.java
+++ b/src/sqlancer/oxla/OxlaToStringVisitor.java
@@ -52,10 +52,10 @@ public class OxlaToStringVisitor extends NewToStringVisitor<OxlaExpression> {
         sb.append(" FROM ");
         visit(select.getFromList());
 
-        if (!select.getFromList().isEmpty() && !select.getJoinList().isEmpty()) {
-            sb.append(", ");
-        }
         if (!select.getJoinList().isEmpty()) {
+            if (!select.getFromList().isEmpty()) {
+                sb.append(", ");
+            }
             visit(select.getJoinList());
         }
         if (select.getWhereClause() != null) {

--- a/src/sqlancer/oxla/OxlaToStringVisitor.java
+++ b/src/sqlancer/oxla/OxlaToStringVisitor.java
@@ -52,7 +52,10 @@ public class OxlaToStringVisitor extends NewToStringVisitor<OxlaExpression> {
         sb.append(" FROM ");
         visit(select.getFromList());
 
-        if (select.getJoinList() != null) {
+        if (!select.getFromList().isEmpty() && !select.getJoinList().isEmpty()) {
+            sb.append(", ");
+        }
+        if (!select.getJoinList().isEmpty()) {
             visit(select.getJoinList());
         }
         if (select.getWhereClause() != null) {

--- a/src/sqlancer/oxla/ast/OxlaCast.java
+++ b/src/sqlancer/oxla/ast/OxlaCast.java
@@ -1,0 +1,16 @@
+package sqlancer.oxla.ast;
+
+import sqlancer.oxla.schema.OxlaDataType;
+
+public class OxlaCast implements OxlaExpression {
+    public final OxlaExpression expression;
+    public final OxlaDataType dataType;
+
+    public OxlaCast(OxlaExpression expression, OxlaDataType dataType) {
+        if (expression == null) {
+            throw new AssertionError("expression was null.");
+        }
+        this.expression = expression;
+        this.dataType = dataType;
+    }
+}

--- a/src/sqlancer/oxla/ast/OxlaConstant.java
+++ b/src/sqlancer/oxla/ast/OxlaConstant.java
@@ -31,14 +31,15 @@ public abstract class OxlaConstant implements OxlaExpression {
             case INTERVAL:
                 return createIntervalConstant(randomly.getInteger32(), randomly.getInteger32(), randomly.getLong());
             case JSON:
-                return createJsonConstant(String.format("{\"key\": \"%s\"}", randomly.getString()));
+                return createJsonConstant(randomly.getString());
             case TEXT:
-                return createTextConstant(String.format("TEXT '%s'", randomly.getString()));
+                return createTextConstant(randomly.getString());
             case TIME:
                 return createTimeConstant(randomly.getInteger32());
             case TIMESTAMP:
-            case TIMESTAMPTZ:
                 return createTimestampConstant(randomly.getLong());
+            case TIMESTAMPTZ:
+                return createTimestamptzConstant(randomly.getLong());
             default:
                 throw new AssertionError();
         }

--- a/src/sqlancer/oxla/ast/OxlaConstant.java
+++ b/src/sqlancer/oxla/ast/OxlaConstant.java
@@ -231,7 +231,7 @@ public abstract class OxlaConstant implements OxlaExpression {
             final String valString = value
                     .replace("'", "")
                     .replace("\\", "\\\\");
-            return String.format("'%s'", valString);
+            return String.format("TEXT '%s'", valString);
         }
     }
 

--- a/src/sqlancer/oxla/ast/OxlaConstant.java
+++ b/src/sqlancer/oxla/ast/OxlaConstant.java
@@ -13,9 +13,9 @@ public abstract class OxlaConstant implements OxlaExpression {
     private OxlaConstant() {
     }
 
-    public static OxlaConstant getRandom(OxlaGlobalState state) {
+    public static OxlaConstant getRandomForType(OxlaGlobalState state, OxlaDataType type) {
         final Randomly randomly = state.getRandomly();
-        switch (OxlaDataType.getRandomType()) {
+        switch (type) {
             case BOOLEAN:
                 return createBooleanConstant(Randomly.getBoolean());
             case DATE:
@@ -42,6 +42,10 @@ public abstract class OxlaConstant implements OxlaExpression {
             default:
                 throw new AssertionError();
         }
+    }
+
+    public static OxlaConstant getRandom(OxlaGlobalState state) {
+        return getRandomForType(state, OxlaDataType.getRandomType());
     }
 
     public static OxlaConstant createNullConstant() {

--- a/src/sqlancer/oxla/ast/OxlaConstant.java
+++ b/src/sqlancer/oxla/ast/OxlaConstant.java
@@ -1,5 +1,6 @@
 package sqlancer.oxla.ast;
 
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 
@@ -183,7 +184,7 @@ public abstract class OxlaConstant implements OxlaExpression {
 
         @Override
         public String toString() {
-            return String.format("TIME '%s'", new SimpleDateFormat("yyyy-MM-dd").format(new Timestamp(value)));
+            return String.format("TIME '%s'", new Time(value));
         }
     }
 

--- a/src/sqlancer/oxla/ast/OxlaConstant.java
+++ b/src/sqlancer/oxla/ast/OxlaConstant.java
@@ -57,11 +57,11 @@ public abstract class OxlaConstant implements OxlaExpression {
     }
 
     public static OxlaConstant createFloat32Constant(float value) {
-        return new OxlaFloatConstant(value);
+        return new OxlaFloat32Constant(value);
     }
 
     public static OxlaConstant createFloat64Constant(double value) {
-        return new OxlaFloatConstant(value);
+        return new OxlaFloat64Constant(value);
     }
 
     public static OxlaConstant createInt32Constant(int value) {
@@ -133,22 +133,36 @@ public abstract class OxlaConstant implements OxlaExpression {
         }
     }
 
-    public static class OxlaFloatConstant extends OxlaConstant {
-        public final double value;
+    public static class OxlaFloat32Constant extends OxlaConstant {
+        public final float value;
 
-        public OxlaFloatConstant(double value) {
-            this.value = value;
-        }
-
-        public OxlaFloatConstant(float value) {
+        public OxlaFloat32Constant(float value) {
             this.value = value;
         }
 
         @Override
         public String toString() {
-            if (value == Double.POSITIVE_INFINITY || (float) value == Float.POSITIVE_INFINITY) {
+            if (value == Float.POSITIVE_INFINITY) {
                 return "'infinity'";
-            } else if (value == Double.NEGATIVE_INFINITY || (float) value == Float.NEGATIVE_INFINITY) {
+            } else if (value == Float.NEGATIVE_INFINITY) {
+                return "'-infinity'";
+            }
+            return String.valueOf(value);
+        }
+    }
+
+    public static class OxlaFloat64Constant extends OxlaConstant {
+        public final double value;
+
+        public OxlaFloat64Constant(double value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            if (value == Double.POSITIVE_INFINITY) {
+                return "'infinity'";
+            } else if (value == Double.NEGATIVE_INFINITY) {
                 return "'-infinity'";
             }
             return String.valueOf(value);

--- a/src/sqlancer/oxla/ast/OxlaConstant.java
+++ b/src/sqlancer/oxla/ast/OxlaConstant.java
@@ -261,7 +261,7 @@ public abstract class OxlaConstant implements OxlaExpression {
 
         @Override
         public String toString() {
-            return String.format("TIMESTAMP '%s'", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(value));
+            return String.format("TIMESTAMP WITHOUT TIME ZONE '%s'", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(value));
         }
     }
 
@@ -274,7 +274,7 @@ public abstract class OxlaConstant implements OxlaExpression {
 
         @Override
         public String toString() {
-            return String.format("TIMESTAMPTZ '%s'", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss+00").format(value));
+            return String.format("TIMESTAMP WITH TIME ZONE '%s'", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss+00").format(value));
         }
     }
 }

--- a/src/sqlancer/oxla/ast/OxlaOperator.java
+++ b/src/sqlancer/oxla/ast/OxlaOperator.java
@@ -4,9 +4,9 @@ import sqlancer.common.ast.BinaryOperatorNode;
 
 public abstract class OxlaOperator implements BinaryOperatorNode.Operator {
     public final String textRepresentation;
-    public final OxlaOperatorOverload overload;
+    public final OxlaTypeOverload overload;
 
-    public OxlaOperator(String textRepresentation, OxlaOperatorOverload overload) {
+    public OxlaOperator(String textRepresentation, OxlaTypeOverload overload) {
         this.textRepresentation = textRepresentation;
         this.overload = overload;
     }

--- a/src/sqlancer/oxla/ast/OxlaTypeOverload.java
+++ b/src/sqlancer/oxla/ast/OxlaTypeOverload.java
@@ -2,16 +2,16 @@ package sqlancer.oxla.ast;
 
 import sqlancer.oxla.schema.OxlaDataType;
 
-public class OxlaOperatorOverload {
+public class OxlaTypeOverload {
     public final OxlaDataType[] inputTypes;
     public final OxlaDataType returnType;
 
-    public OxlaOperatorOverload(OxlaDataType[] inputTypes, OxlaDataType returnType) {
+    public OxlaTypeOverload(OxlaDataType[] inputTypes, OxlaDataType returnType) {
         this.inputTypes = inputTypes;
         this.returnType = returnType;
     }
 
-    public OxlaOperatorOverload(OxlaDataType inputType, OxlaDataType returnType) {
+    public OxlaTypeOverload(OxlaDataType inputType, OxlaDataType returnType) {
         this.inputTypes = new OxlaDataType[]{inputType};
         this.returnType = returnType;
     }

--- a/src/sqlancer/oxla/ast/OxlaUnaryPostfixOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaUnaryPostfixOperation.java
@@ -13,7 +13,7 @@ public class OxlaUnaryPostfixOperation extends NewUnaryPostfixOperatorNode<OxlaE
     }
 
     public static class OxlaUnaryPostfixOperator extends OxlaOperator {
-        public OxlaUnaryPostfixOperator(String textRepresentation, OxlaOperatorOverload overload) {
+        public OxlaUnaryPostfixOperator(String textRepresentation, OxlaTypeOverload overload) {
             super(textRepresentation, overload);
         }
     }
@@ -21,30 +21,30 @@ public class OxlaUnaryPostfixOperation extends NewUnaryPostfixOperatorNode<OxlaE
     // FIXME Imho, this class shouldn't hardcode the operators, but query the database for them instead.
     //       Sadly, Oxla does not support every pg_* table in the metastore so it's impossible for now.
     public static final List<OxlaOperator> ALL = List.of(
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.DATE, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.FLOAT32, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.FLOAT64, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.INT32, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.INT64, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.INTERVAL, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.JSON, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.TEXT, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.TIME, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.TIMESTAMP, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NULL", new OxlaOperatorOverload(OxlaDataType.TIMESTAMPTZ, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.DATE, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.FLOAT32, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.FLOAT64, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.INT32, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.INT64, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.INTERVAL, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.JSON, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.TEXT, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.TIME, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.TIMESTAMP, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaOperatorOverload(OxlaDataType.TIMESTAMPTZ, OxlaDataType.BOOLEAN))
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.DATE, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.FLOAT32, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.INT32, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.INTERVAL, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.JSON, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.TEXT, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.TIME, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.TIMESTAMP, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NULL", new OxlaTypeOverload(OxlaDataType.TIMESTAMPTZ, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.DATE, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.FLOAT32, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.INT32, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.INTERVAL, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.JSON, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.TEXT, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.TIME, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.TIMESTAMP, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPostfixOperator("IS NOT NULL", new OxlaTypeOverload(OxlaDataType.TIMESTAMPTZ, OxlaDataType.BOOLEAN))
     );
     public static final OxlaOperator IS_NULL = ALL.get(0);
 }

--- a/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
@@ -39,8 +39,8 @@ public class OxlaUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<OxlaExp
             new OxlaUnaryPrefixOperator("|/", new OxlaTypeOverload(OxlaDataType.FLOAT32, OxlaDataType.FLOAT64)),
             new OxlaUnaryPrefixOperator("||/", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64)),
             new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.INT32, OxlaDataType.INT32)),
-            new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.INT64)),
-            new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.TEXT, OxlaDataType.TEXT))
+            new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.INT64))
+//            new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.TEXT, OxlaDataType.TEXT)) // FIXME Generate only for REGEXes.
     );
     public static final OxlaOperator NOT = ALL.get(13);
 

--- a/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
@@ -14,7 +14,7 @@ public class OxlaUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<OxlaExp
     }
 
     public static class OxlaUnaryPrefixOperator extends OxlaOperator {
-        public OxlaUnaryPrefixOperator(String textRepresentation, OxlaOperatorOverload overload) {
+        public OxlaUnaryPrefixOperator(String textRepresentation, OxlaTypeOverload overload) {
             super(textRepresentation, overload);
         }
     }
@@ -22,25 +22,25 @@ public class OxlaUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<OxlaExp
     // FIXME Imho, this class shouldn't hardcode the operators, but query the database for them instead.
     //       Sadly, Oxla does not support every pg_* table in the metastore so it's impossible for now.
     public static final List<OxlaOperator> ALL = List.of(
-            new OxlaUnaryPrefixOperator("+", new OxlaOperatorOverload(OxlaDataType.FLOAT32, OxlaDataType.FLOAT32)),
-            new OxlaUnaryPrefixOperator("+", new OxlaOperatorOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64)),
-            new OxlaUnaryPrefixOperator("+", new OxlaOperatorOverload(OxlaDataType.INT32, OxlaDataType.INT32)),
-            new OxlaUnaryPrefixOperator("+", new OxlaOperatorOverload(OxlaDataType.INT64, OxlaDataType.INT64)),
-            new OxlaUnaryPrefixOperator("-", new OxlaOperatorOverload(OxlaDataType.FLOAT32, OxlaDataType.FLOAT32)),
-            new OxlaUnaryPrefixOperator("-", new OxlaOperatorOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64)),
-            new OxlaUnaryPrefixOperator("-", new OxlaOperatorOverload(OxlaDataType.INT32, OxlaDataType.INT32)),
-            new OxlaUnaryPrefixOperator("-", new OxlaOperatorOverload(OxlaDataType.INT64, OxlaDataType.INT64)),
-            new OxlaUnaryPrefixOperator("-", new OxlaOperatorOverload(OxlaDataType.INTERVAL, OxlaDataType.INTERVAL)),
-            new OxlaUnaryPrefixOperator("@", new OxlaOperatorOverload(OxlaDataType.FLOAT32, OxlaDataType.FLOAT32)),
-            new OxlaUnaryPrefixOperator("@", new OxlaOperatorOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64)),
-            new OxlaUnaryPrefixOperator("@", new OxlaOperatorOverload(OxlaDataType.INT32, OxlaDataType.INT32)),
-            new OxlaUnaryPrefixOperator("@", new OxlaOperatorOverload(OxlaDataType.INT64, OxlaDataType.INT64)),
-            new OxlaUnaryPrefixOperator("NOT", new OxlaOperatorOverload(OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN)),
-            new OxlaUnaryPrefixOperator("|/", new OxlaOperatorOverload(OxlaDataType.FLOAT32, OxlaDataType.FLOAT64)),
-            new OxlaUnaryPrefixOperator("||/", new OxlaOperatorOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64)),
-            new OxlaUnaryPrefixOperator("~", new OxlaOperatorOverload(OxlaDataType.INT32, OxlaDataType.INT32)),
-            new OxlaUnaryPrefixOperator("~", new OxlaOperatorOverload(OxlaDataType.INT64, OxlaDataType.INT64)),
-            new OxlaUnaryPrefixOperator("~", new OxlaOperatorOverload(OxlaDataType.TEXT, OxlaDataType.TEXT))
+            new OxlaUnaryPrefixOperator("+", new OxlaTypeOverload(OxlaDataType.FLOAT32, OxlaDataType.FLOAT32)),
+            new OxlaUnaryPrefixOperator("+", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64)),
+            new OxlaUnaryPrefixOperator("+", new OxlaTypeOverload(OxlaDataType.INT32, OxlaDataType.INT32)),
+            new OxlaUnaryPrefixOperator("+", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.INT64)),
+            new OxlaUnaryPrefixOperator("-", new OxlaTypeOverload(OxlaDataType.FLOAT32, OxlaDataType.FLOAT32)),
+            new OxlaUnaryPrefixOperator("-", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64)),
+            new OxlaUnaryPrefixOperator("-", new OxlaTypeOverload(OxlaDataType.INT32, OxlaDataType.INT32)),
+            new OxlaUnaryPrefixOperator("-", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.INT64)),
+            new OxlaUnaryPrefixOperator("-", new OxlaTypeOverload(OxlaDataType.INTERVAL, OxlaDataType.INTERVAL)),
+            new OxlaUnaryPrefixOperator("@", new OxlaTypeOverload(OxlaDataType.FLOAT32, OxlaDataType.FLOAT32)),
+            new OxlaUnaryPrefixOperator("@", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64)),
+            new OxlaUnaryPrefixOperator("@", new OxlaTypeOverload(OxlaDataType.INT32, OxlaDataType.INT32)),
+            new OxlaUnaryPrefixOperator("@", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.INT64)),
+            new OxlaUnaryPrefixOperator("NOT", new OxlaTypeOverload(OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN)),
+            new OxlaUnaryPrefixOperator("|/", new OxlaTypeOverload(OxlaDataType.FLOAT32, OxlaDataType.FLOAT64)),
+            new OxlaUnaryPrefixOperator("||/", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64)),
+            new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.INT32, OxlaDataType.INT32)),
+            new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.INT64)),
+            new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.TEXT, OxlaDataType.TEXT))
     );
     public static final OxlaOperator NOT = ALL.get(13);
 

--- a/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
+++ b/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
@@ -39,34 +39,11 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
         if (Randomly.getBooleanWithSmallProbability()) {
             return OxlaConstant.createNullConstant();
         }
-        switch (type) {
-            case BOOLEAN:
-                return OxlaConstant.createBooleanConstant(Randomly.getBoolean());
-            case DATE:
-                return OxlaConstant.createDateConstant(randomly.getInteger32());
-            case FLOAT32:
-                return OxlaConstant.createFloat32Constant(randomly.getFloat());
-            case FLOAT64:
-                return OxlaConstant.createFloat64Constant(randomly.getDouble());
-            case INT32:
-                return OxlaConstant.createInt32Constant(randomly.getInteger32());
-            case INT64:
-                return OxlaConstant.createInt64Constant(randomly.getLong());
-            case INTERVAL:
-                return OxlaConstant.createIntervalConstant(randomly.getInteger32(), randomly.getInteger32(), randomly.getLong());
-            case JSON:
-                return OxlaConstant.createJsonConstant(randomly.getString()); // TODO: Valid JSON generation.
-            case TEXT:
-                return OxlaConstant.createTextConstant(randomly.getString());
-            case TIME:
-                return OxlaConstant.createTimeConstant(randomly.getInteger32());
-            case TIMESTAMP:
-                return OxlaConstant.createTimestampConstant(randomly.getInteger());
-            case TIMESTAMPTZ:
-                return OxlaConstant.createTimestamptzConstant(randomly.getInteger());
-            default:
-                throw new AssertionError(type);
+        OxlaExpression expression = OxlaConstant.getRandom(globalState);
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            return new OxlaCast(expression, type);
         }
+        return expression;
     }
 
     @Override

--- a/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
+++ b/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
@@ -16,7 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpression, OxlaColumn, OxlaDataType> implements NoRECGenerator<OxlaSelect, OxlaJoin, OxlaExpression, OxlaTable, OxlaColumn> {
+public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpression, OxlaColumn, OxlaDataType>
+        implements NoRECGenerator<OxlaSelect, OxlaJoin, OxlaExpression, OxlaTable, OxlaColumn> {
     private final OxlaGlobalState globalState;
     private final Randomly randomly;
     private List<OxlaTable> tables;
@@ -95,7 +96,10 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
         //          - generate cast expression if the cast is explicit.
         //       2. (?) Throw an error if the resulting list is empty.
         //       Potentially add a boolean switch for the behavior above.
-        return new OxlaColumnReference(Randomly.fromList(columns.stream().filter(column -> (column.getType() == type)).collect(Collectors.toList())));
+        return new OxlaColumnReference(Randomly.fromList(columns
+                .stream()
+                .filter(column -> (column.getType() == type))
+                .collect(Collectors.toList())));
     }
 
     @Override

--- a/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
+++ b/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
@@ -18,12 +18,10 @@ import java.util.stream.Stream;
 public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpression, OxlaColumn, OxlaDataType>
         implements NoRECGenerator<OxlaSelect, OxlaJoin, OxlaExpression, OxlaTable, OxlaColumn> {
     private final OxlaGlobalState globalState;
-    private final Randomly randomly;
     private List<OxlaTable> tables;
 
     public OxlaExpressionGenerator(OxlaGlobalState globalState) {
         this.globalState = globalState;
-        this.randomly = globalState.getRandomly();
     }
 
     private enum ExpressionType {
@@ -39,9 +37,10 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
         if (Randomly.getBooleanWithSmallProbability()) {
             return OxlaConstant.createNullConstant();
         }
-        OxlaExpression expression = OxlaConstant.getRandom(globalState);
+        // FIXME Imho, we should generate a random constant that is implicitly or explicitly cast-able to the wanted type.
+        OxlaExpression expression = OxlaConstant.getRandomForType(globalState, type);
         if (Randomly.getBooleanWithRatherLowProbability()) {
-            return new OxlaCast(expression, type);
+            return new OxlaCast(expression, type); // Explicit cast to self type.
         }
         return expression;
     }

--- a/src/sqlancer/oxla/schema/OxlaDataType.java
+++ b/src/sqlancer/oxla/schema/OxlaDataType.java
@@ -5,6 +5,11 @@ import sqlancer.Randomly;
 public enum OxlaDataType {
     BOOLEAN, DATE, FLOAT32, FLOAT64, INT32, INT64, INTERVAL, JSON, TEXT, TIME, TIMESTAMP, TIMESTAMPTZ;
 
+    @Override
+    public String toString() {
+        return OxlaDataType.toString(this);
+    }
+
     public static final OxlaDataType[] NUMERIC = new OxlaDataType[]{INT32, INT64, FLOAT32, FLOAT64};
 
     public static OxlaDataType getRandomType() {


### PR DESCRIPTION
Implements `NoRECGenerator` interface in `OxlaExpressionGenerator`.
Instantiates the `NoREC` oracle in `OxlaOracleFactory`.
Adds list(s) of common errors that the database can return (and which should be ignored for invalid queries).
Adds `OxlaCast` node.
Adds a random chance that the generated literals will contain a cast.
Fixes `OxlaToStringVistior` which would:
* ignore the tables in both sides of `JOIN`.
* not prepending a comma before JOINs if the table fetch list wasn't empty.

Refactors `OxlaOperatorOverload` into `OxlaTypeOverload`.
Refactors `OxlaConstant` a bit:
* Separate classes for `Float32` and `Float64` (as they require specific handling).
* various fixes for `JSON`, `TIME` types.


Running the `NoREC` oracle caught the following bugs:
https://oxla.atlassian.net/browse/OXLA-8292
https://oxla.atlassian.net/browse/OXLA-8291
