### PR TITLE
OXLA-8195 Implement operators supported in Oxla.

### DIFF
--- a/src/sqlancer/oxla/OxlaBugs.java
+++ b/src/sqlancer/oxla/OxlaBugs.java
@@ -23,4 +23,8 @@ public final class OxlaBugs {
     /// See: https://oxla.atlassian.net/browse/OXLA-8330
     /// Oxla parses ~~, !~~, ~~*, !~~* operators incorrectly.
     public static boolean bugOxla8330 = true;
+
+    /// See: https://oxla.atlassian.net/browse/OXLA-8332
+    /// Oxla returns Internal Compiler Error for NULL literal JSON extract(s).
+    public static boolean bugOxla8332 = true;
 }

--- a/src/sqlancer/oxla/OxlaBugs.java
+++ b/src/sqlancer/oxla/OxlaBugs.java
@@ -4,11 +4,23 @@ public final class OxlaBugs {
     private OxlaBugs() {
     }
 
-    // https://oxla.atlassian.net/browse/OXLA-3376
-    // Valid INT_MIN value results in an "Integer literal error. Value of literal exceeds range." parsing error.
+    /// See: https://oxla.atlassian.net/browse/OXLA-3376
+    /// Valid INT_MIN value results in an "Integer literal error. Value of literal exceeds range." parsing error.
     public static boolean bugOxla3376 = true;
 
-    // https://oxla.atlassian.net/browse/OXLA-8323
-    // Errors caused in JOIN's WHERE condition return internal error non-deterministically.
+    /// See: https://oxla.atlassian.net/browse/OXLA-8323
+    /// Errors caused in JOIN's WHERE condition return internal error non-deterministically.
     public static boolean bugOxla8323 = true;
+
+    /// See: https://oxla.atlassian.net/browse/OXLA-8328
+    /// Adding/Subtracting large integers to/from a date will crash Oxla in Debug builds, and fail silently in Release.
+    public static boolean bugOxla8328 = true;
+
+    /// See: https://oxla.atlassian.net/browse/OXLA-8329
+    /// Oxla instantly crashes for REGEX patterns containing invalid symbols.
+    public static boolean bugOxla8329 = true;
+
+    /// See: https://oxla.atlassian.net/browse/OXLA-8330
+    /// Oxla parses ~~, !~~, ~~*, !~~* operators incorrectly.
+    public static boolean bugOxla8330 = true;
 }

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -16,7 +16,8 @@ public class OxlaCommon {
             Pattern.compile("operator is not unique: (.*)")
     );
     public static final List<String> JOIN_ERRORS = List.of(
-            "invalid JOIN ON clause condition. Only equi join is supported"
+            "invalid JOIN ON clause condition. Only equi join is supported",
+            "both sides of \"=\" operator in JOIN ON condition must come from different sources"
     );
     public static final List<String> GROUP_BY_ERRORS = List.of(
             "non-integer constant in GROUP BY"

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -13,7 +13,9 @@ public class OxlaCommon {
     );
     public static final List<Pattern> SYNTAX_REGEX_ERRORS = List.of(
             Pattern.compile("operator \"[^\"]+\" is not unique"),
-            Pattern.compile("operator is not unique: (.*)")
+            Pattern.compile("operator is not unique: (.*)"),
+            Pattern.compile("Failed to compile '[^']+' as a regular expression pattern"),
+            Pattern.compile("Could not locate this time zone:\\s+.*(, because:)\\s+.*")
     );
     public static final List<String> JOIN_ERRORS = List.of(
             "invalid JOIN ON clause condition. Only equi join is supported",
@@ -32,12 +34,13 @@ public class OxlaCommon {
             Pattern.compile("ORDER BY position (\\d+) is not in select list")
     );
     public static final List<String> EXPRESSION_ERRORS = List.of(
-            "input is out of range"
+            "out of range",
+            "division by zero"
     );
     public static final List<Pattern> EXPRESSION_REGEX_ERRORS = List.of(
             Pattern.compile("operator is not unique:\\s+(.+)"),
             Pattern.compile("operator does not exist:\\s+(.+)")
-            );
+    );
 
     public static List<String> bugErrors() {
         List<String> list = new ArrayList<>();
@@ -46,6 +49,9 @@ public class OxlaCommon {
         }
         if (OxlaBugs.bugOxla8323) {
             list.add("Invalidated shared object in join processors");
+        }
+        if (OxlaBugs.bugOxla8330) {
+            list.add("syntax error, unexpected RE_CI_MATCH");
         }
         return list;
     }

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -34,7 +34,10 @@ public class OxlaCommon {
     public static final List<String> EXPRESSION_ERRORS = List.of(
             "input is out of range"
     );
-    public static final List<Pattern> EXPRESSION_REGEX_ERRORS = List.of();
+    public static final List<Pattern> EXPRESSION_REGEX_ERRORS = List.of(
+            Pattern.compile("operator is not unique:\\s+(.+)"),
+            Pattern.compile("operator does not exist:\\s+(.+)")
+            );
 
     public static List<String> bugErrors() {
         List<String> list = new ArrayList<>();

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -1,5 +1,7 @@
 package sqlancer.oxla;
 
+import sqlancer.common.query.ExpectedErrors;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -60,4 +62,17 @@ public class OxlaCommon {
         }
         return list;
     }
+
+    public static final ExpectedErrors ALL_ERRORS = ExpectedErrors.newErrors()
+            .with(OxlaCommon.SYNTAX_ERRORS)
+            .withRegex(OxlaCommon.SYNTAX_REGEX_ERRORS)
+            .with(OxlaCommon.JOIN_ERRORS)
+            .with(OxlaCommon.GROUP_BY_ERRORS)
+            .withRegex(OxlaCommon.GROUP_BY_REGEX_ERRORS)
+            .with(OxlaCommon.ORDER_BY_ERRORS)
+            .withRegex(OxlaCommon.ORDER_BY_REGEX_ERRORS)
+            .with(OxlaCommon.EXPRESSION_ERRORS)
+            .withRegex(OxlaCommon.EXPRESSION_REGEX_ERRORS)
+            .with(OxlaCommon.bugErrors())
+            .build();
 }

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -24,6 +24,9 @@ public class OxlaCommon {
             "both sides of \"=\" operator in JOIN ON condition must come from different sources",
             "expression on one side of \"=\" operator in JOIN ON condition must come from exactly one source"
     );
+    public static final List<Pattern> JOIN_REGEX_ERRORS = List.of(
+            Pattern.compile("could not identify an ordering operator for type\\s+.*")
+    );
     public static final List<String> GROUP_BY_ERRORS = List.of(
             "non-integer constant in GROUP BY"
     );
@@ -69,6 +72,7 @@ public class OxlaCommon {
             .with(OxlaCommon.SYNTAX_ERRORS)
             .withRegex(OxlaCommon.SYNTAX_REGEX_ERRORS)
             .with(OxlaCommon.JOIN_ERRORS)
+            .withRegex(OxlaCommon.JOIN_REGEX_ERRORS)
             .with(OxlaCommon.GROUP_BY_ERRORS)
             .withRegex(OxlaCommon.GROUP_BY_REGEX_ERRORS)
             .with(OxlaCommon.ORDER_BY_ERRORS)

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -17,7 +17,7 @@ public class OxlaCommon {
             Pattern.compile("operator \"[^\"]+\" is not unique"),
             Pattern.compile("operator is not unique: (.*)"),
             Pattern.compile("Failed to compile '[^']+' as a regular expression pattern"),
-            Pattern.compile("Could not locate this time zone:\\s+.*(, because:)\\s+.*")
+            Pattern.compile("Could not locate this time zone:.*")
     );
     public static final List<String> JOIN_ERRORS = List.of(
             "invalid JOIN ON clause condition. Only equi join is supported",

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -36,7 +36,8 @@ public class OxlaCommon {
     );
     public static final List<String> EXPRESSION_ERRORS = List.of(
             "out of range",
-            "division by zero"
+            "division by zero",
+            "zero raised to a negative power is undefined"
     );
     public static final List<Pattern> EXPRESSION_REGEX_ERRORS = List.of(
             Pattern.compile("operator is not unique:\\s+(.+)"),
@@ -53,6 +54,9 @@ public class OxlaCommon {
         }
         if (OxlaBugs.bugOxla8330) {
             list.add("syntax error, unexpected RE_CI_MATCH");
+        }
+        if (OxlaBugs.bugOxla8332) {
+            list.add("std::get: wrong index for variant");
         }
         return list;
     }

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -39,7 +39,9 @@ public class OxlaCommon {
     public static final List<String> EXPRESSION_ERRORS = List.of(
             "out of range",
             "division by zero",
-            "zero raised to a negative power is undefined"
+            "zero raised to a negative power is undefined",
+            "LIMIT must not be negative",
+            "OFFSET must not be negative"
     );
     public static final List<Pattern> EXPRESSION_REGEX_ERRORS = List.of(
             Pattern.compile("operator is not unique:\\s+(.+)"),

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -19,7 +19,8 @@ public class OxlaCommon {
     );
     public static final List<String> JOIN_ERRORS = List.of(
             "invalid JOIN ON clause condition. Only equi join is supported",
-            "both sides of \"=\" operator in JOIN ON condition must come from different sources"
+            "both sides of \"=\" operator in JOIN ON condition must come from different sources",
+            "expression on one side of \"=\" operator in JOIN ON condition must come from exactly one source"
     );
     public static final List<String> GROUP_BY_ERRORS = List.of(
             "non-integer constant in GROUP BY"

--- a/src/sqlancer/oxla/OxlaOracleFactory.java
+++ b/src/sqlancer/oxla/OxlaOracleFactory.java
@@ -4,7 +4,6 @@ import sqlancer.OracleFactory;
 import sqlancer.common.oracle.CompositeTestOracle;
 import sqlancer.common.oracle.NoRECOracle;
 import sqlancer.common.oracle.TestOracle;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.oxla.gen.OxlaExpressionGenerator;
 import sqlancer.oxla.oracle.OxlaFuzzer;
 import sqlancer.oxla.oracle.OxlaPivotedQuerySynthesisOracle;
@@ -17,19 +16,7 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
         @Override
         public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
             OxlaExpressionGenerator generator = new OxlaExpressionGenerator(globalState);
-            ExpectedErrors errors = ExpectedErrors.newErrors()
-                    .with(OxlaCommon.SYNTAX_ERRORS)
-                    .withRegex(OxlaCommon.SYNTAX_REGEX_ERRORS)
-                    .with(OxlaCommon.JOIN_ERRORS)
-                    .with(OxlaCommon.GROUP_BY_ERRORS)
-                    .withRegex(OxlaCommon.GROUP_BY_REGEX_ERRORS)
-                    .with(OxlaCommon.ORDER_BY_ERRORS)
-                    .withRegex(OxlaCommon.ORDER_BY_REGEX_ERRORS)
-                    .with(OxlaCommon.EXPRESSION_ERRORS)
-                    .withRegex(OxlaCommon.EXPRESSION_REGEX_ERRORS)
-                    .with(OxlaCommon.bugErrors())
-                    .build();
-            return new NoRECOracle<>(globalState, generator, errors);
+            return new NoRECOracle<>(globalState, generator, OxlaCommon.ALL_ERRORS);
         }
     },
     PQS {
@@ -55,7 +42,7 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
     FUZZER {
         @Override
         public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
-            return new OxlaFuzzer(globalState);
+            return new OxlaFuzzer(globalState, OxlaCommon.ALL_ERRORS);
         }
     }
 }

--- a/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
@@ -6,7 +6,6 @@ import sqlancer.common.ast.newast.NewBinaryOperatorNode;
 import sqlancer.oxla.schema.OxlaDataType;
 
 import java.util.List;
-import java.util.function.IntPredicate;
 
 public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
         implements OxlaExpression {
@@ -21,8 +20,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
         if (leftValue == null || rightValue == null) {
             return null;
         }
+        if (leftValue instanceof OxlaConstant.OxlaNullConstant || rightValue instanceof OxlaConstant.OxlaNullConstant) {
+            return OxlaConstant.createNullConstant();
+        }
         return ((OxlaBinaryOperation.OxlaBinaryOperator) op).apply(new OxlaConstant[]{leftValue, rightValue});
-
     }
 
     public static class OxlaBinaryOperator extends OxlaOperator {
@@ -175,80 +176,80 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
 
     public static final List<OxlaOperator> ARITHMETIC = List.of(
             // Addition
-            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyAdd),
-            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applyAdd),
             new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.INT32}, OxlaDataType.DATE), OxlaBinaryOperation::applyAdd),
             new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
             new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.TIME}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
-            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyAdd),
             new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyAdd),
-            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyAdd),
             new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.DATE}, OxlaDataType.DATE), OxlaBinaryOperation::applyAdd),
             new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyAdd),
             new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.DATE}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
             new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyAdd),
-            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.TIMESTAMP}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
             new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.TIMESTAMPTZ), OxlaBinaryOperation::applyAdd),
-            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyAdd),
-            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyAdd),
-            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
-            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMPTZ), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.TIMESTAMP}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.TIME}, OxlaDataType.TIME), OxlaBinaryOperation::applyAdd),
             new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.DATE}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
             new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.INTERVAL}, OxlaDataType.TIME), OxlaBinaryOperation::applyAdd),
-            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.TIME}, OxlaDataType.TIME), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMPTZ), OxlaBinaryOperation::applyAdd),
             // Subtraction
-            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applySub),
-            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applySub),
             new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.DATE}, OxlaDataType.INT32), OxlaBinaryOperation::applySub),
             new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.INT32}, OxlaDataType.DATE), OxlaBinaryOperation::applySub),
             new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applySub),
-            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applySub),
-            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applySub),
-            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applySub),
-            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applySub),
-            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applySub),
-            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applySub),
             new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.INTERVAL}, OxlaDataType.TIME), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applySub),
             new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applySub),
             new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMP}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applySub),
             new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMPTZ), OxlaBinaryOperation::applySub),
             new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applySub),
-            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.INTERVAL}, OxlaDataType.TIME), OxlaBinaryOperation::applySub),
-            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applySub),
             // Multiplication
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT32}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.FLOAT32}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT64}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.FLOAT64}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
-            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMul),
             new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.FLOAT32}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.FLOAT64}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT32}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT64}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
             // Division
-            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyDiv),
-            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applyDiv),
-            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyDiv),
             new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyDiv),
-            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyDiv),
             new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyDiv),
-            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT32}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyDiv),
-            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT64}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyDiv),
             new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.FLOAT32}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyDiv),
             new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.FLOAT64}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyDiv),
-            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyDiv),
-            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT32}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT64}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyDiv),
             // Modulus
-            new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyMod),
-            new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyMod),
+            new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyMod),
             new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMod),
-            new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyMod)
+            new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyMod),
+            new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyMod)
     );
 
     public static final List<OxlaOperator> REGEX = List.of(
@@ -269,75 +270,113 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
     );
 
     public static final List<OxlaOperator> BINARY = List.of(
-            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), null),
-            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), null),
-            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
-            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null),
+            new OxlaBinaryOperator("#", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
+            new OxlaBinaryOperator("#", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null),
             new OxlaBinaryOperator("&", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
             new OxlaBinaryOperator("&", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null),
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), null),
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), null),
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null),
             new OxlaBinaryOperator("|", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
-            new OxlaBinaryOperator("|", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null),
-            new OxlaBinaryOperator("#", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
-            new OxlaBinaryOperator("#", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null)
+            new OxlaBinaryOperator("|", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null)
     );
 
     public static final List<OxlaOperator> MISC = List.of(
-            new OxlaBinaryOperator("AT TIME ZONE", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TEXT}, OxlaDataType.TIMESTAMPTZ), null),
-            new OxlaBinaryOperator("AT TIME ZONE", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TEXT}, OxlaDataType.TIMESTAMP), null),
             new OxlaBinaryOperator("->", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.JSON, OxlaDataType.INT32}, OxlaDataType.JSON), null),
             new OxlaBinaryOperator("->", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.JSON, OxlaDataType.TEXT}, OxlaDataType.JSON), null),
             new OxlaBinaryOperator("->>", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.JSON, OxlaDataType.INT32}, OxlaDataType.TEXT), null),
-            new OxlaBinaryOperator("->>", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.JSON, OxlaDataType.TEXT}, OxlaDataType.TEXT), null)
+            new OxlaBinaryOperator("->>", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.JSON, OxlaDataType.TEXT}, OxlaDataType.TEXT), null),
+            new OxlaBinaryOperator("AT TIME ZONE", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TEXT}, OxlaDataType.TIMESTAMPTZ), null),
+            new OxlaBinaryOperator("AT TIME ZONE", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TEXT}, OxlaDataType.TIMESTAMP), null)
     );
 
-    private static OxlaConstant applyComparison(OxlaConstant[] constants, IntPredicate comparisonFunction) {
-        if (constants[0] instanceof OxlaConstant.OxlaNullConstant || constants[1] instanceof OxlaConstant.OxlaNullConstant) {
-            return OxlaConstant.createNullConstant();
-        }
-        return OxlaConstant.createBooleanConstant(comparisonFunction.test(constants[0].compareTo(constants[1])));
-    }
-
     private static OxlaConstant applyLess(OxlaConstant[] constants) {
-        return applyComparison(constants, (a) -> a < 0);
+        return OxlaConstant.createBooleanConstant(constants[0].compareTo(constants[1]) < 0);
     }
 
     private static OxlaConstant applyLessEqual(OxlaConstant[] constants) {
-        return applyComparison(constants, (a) -> a <= 0);
+        return OxlaConstant.createBooleanConstant(constants[0].compareTo(constants[1]) <= 0);
     }
 
     private static OxlaConstant applyNotEqual(OxlaConstant[] constants) {
-        return applyComparison(constants, (a) -> a != 0);
+        return OxlaConstant.createBooleanConstant(constants[0].compareTo(constants[1]) != 0);
     }
 
     private static OxlaConstant applyEqual(OxlaConstant[] constants) {
-        return applyComparison(constants, (a) -> a == 0);
+        return OxlaConstant.createBooleanConstant(constants[0].compareTo(constants[1]) == 0);
     }
 
     private static OxlaConstant applyGreater(OxlaConstant[] constants) {
-        return applyComparison(constants, (a) -> a > 0);
+        return OxlaConstant.createBooleanConstant(constants[0].compareTo(constants[1]) > 0);
     }
 
     private static OxlaConstant applyGreaterEqual(OxlaConstant[] constants) {
-        return applyComparison(constants, (a) -> a >= 0);
+        return OxlaConstant.createBooleanConstant(constants[0].compareTo(constants[1]) >= 0);
     }
 
     private static OxlaConstant applyAdd(OxlaConstant[] constants) {
-        throw new AssertionError("not implemented yet.");
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value + ((OxlaConstant.OxlaIntegerConstant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
+            return OxlaConstant.createFloat32Constant(((OxlaConstant.OxlaFloat32Constant) left).value + ((OxlaConstant.OxlaFloat32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
+            return OxlaConstant.createFloat64Constant(((OxlaConstant.OxlaFloat64Constant) left).value + ((OxlaConstant.OxlaFloat64Constant) right).value);
+        }
+        throw new IgnoreMeException(); // Not implemented for type.
     }
 
     private static OxlaConstant applySub(OxlaConstant[] constants) {
-        throw new AssertionError("not implemented yet.");
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value - ((OxlaConstant.OxlaIntegerConstant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
+            return OxlaConstant.createFloat32Constant(((OxlaConstant.OxlaFloat32Constant) left).value - ((OxlaConstant.OxlaFloat32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
+            return OxlaConstant.createFloat64Constant(((OxlaConstant.OxlaFloat64Constant) left).value - ((OxlaConstant.OxlaFloat64Constant) right).value);
+        }
+        throw new IgnoreMeException(); // Not implemented for type.
     }
 
     private static OxlaConstant applyMul(OxlaConstant[] constants) {
-        throw new AssertionError("not implemented yet.");
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value * ((OxlaConstant.OxlaIntegerConstant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
+            return OxlaConstant.createFloat32Constant(((OxlaConstant.OxlaFloat32Constant) left).value * ((OxlaConstant.OxlaFloat32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
+            return OxlaConstant.createFloat64Constant(((OxlaConstant.OxlaFloat64Constant) left).value * ((OxlaConstant.OxlaFloat64Constant) right).value);
+        }
+        throw new IgnoreMeException(); // Not implemented for type.
     }
 
     private static OxlaConstant applyDiv(OxlaConstant[] constants) {
-        throw new AssertionError("not implemented yet.");
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value / ((OxlaConstant.OxlaIntegerConstant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
+            return OxlaConstant.createFloat32Constant(((OxlaConstant.OxlaFloat32Constant) left).value / ((OxlaConstant.OxlaFloat32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
+            return OxlaConstant.createFloat64Constant(((OxlaConstant.OxlaFloat64Constant) left).value / ((OxlaConstant.OxlaFloat64Constant) right).value);
+        }
+        throw new IgnoreMeException(); // Not implemented for type.
     }
 
     private static OxlaConstant applyMod(OxlaConstant[] constants) {
-        throw new AssertionError("not implemented yet.");
+        OxlaConstant left = constants[0];
+        OxlaConstant right = constants[1];
+        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value % ((OxlaConstant.OxlaIntegerConstant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
+            return OxlaConstant.createFloat32Constant(((OxlaConstant.OxlaFloat32Constant) left).value % ((OxlaConstant.OxlaFloat32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
+            return OxlaConstant.createFloat64Constant(((OxlaConstant.OxlaFloat64Constant) left).value % ((OxlaConstant.OxlaFloat64Constant) right).value);
+        }
+        throw new AssertionError(String.format("OxlaBinaryOperationOperation::applyMod failed: %s vs %s", left.getClass(), right.getClass()));
     }
 }

--- a/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
@@ -255,15 +255,17 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
             new OxlaBinaryOperator("!~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
             new OxlaBinaryOperator("!~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
             new OxlaBinaryOperator("!~~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
-            new OxlaBinaryOperator("!~~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.TEXT), null),
             new OxlaBinaryOperator("!~~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
-            new OxlaBinaryOperator("!~~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.TEXT), null),
             new OxlaBinaryOperator("~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
             new OxlaBinaryOperator("~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
             new OxlaBinaryOperator("~~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
-            new OxlaBinaryOperator("~~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.TEXT), null),
-            new OxlaBinaryOperator("~~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
-            new OxlaBinaryOperator("~~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.TEXT), null)
+            new OxlaBinaryOperator("~~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null)
+
+            // FIXME: These overloads take 3 input params - possibly move them to OxlaTernaryNode.
+//            new OxlaBinaryOperator("!~~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
+//            new OxlaBinaryOperator("!~~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
+//            new OxlaBinaryOperator("~~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
+//            new OxlaBinaryOperator("~~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null)
     );
 
     public static final List<OxlaOperator> BINARY = List.of(

--- a/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
@@ -402,7 +402,7 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
         final OxlaConstant left = constants[0];
         final OxlaConstant right = constants[1];
         if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value & ((OxlaConstant.OxlaIntegerConstant) right).value);
+            return OxlaConstant.createInt64Constant((long) Math.pow(((OxlaConstant.OxlaIntegerConstant) left).value, ((OxlaConstant.OxlaIntegerConstant) right).value));
         } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
             return OxlaConstant.createFloat32Constant((float) Math.pow(((OxlaConstant.OxlaFloat32Constant) left).value, ((OxlaConstant.OxlaFloat32Constant) right).value));
         } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {

--- a/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
@@ -2,10 +2,199 @@ package sqlancer.oxla.ast;
 
 import sqlancer.common.ast.BinaryOperatorNode;
 import sqlancer.common.ast.newast.NewBinaryOperatorNode;
+import sqlancer.oxla.schema.OxlaDataType;
+
+import java.util.List;
 
 public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
         implements OxlaExpression {
     public OxlaBinaryOperation(OxlaExpression left, OxlaExpression right, BinaryOperatorNode.Operator op) {
         super(left, right, op);
+    }
+
+    @Override
+    public OxlaConstant getExpectedValue() {
+        OxlaConstant leftValue = getLeft().getExpectedValue();
+        OxlaConstant rightValue = getRight().getExpectedValue();
+        if (leftValue == null || rightValue == null) {
+            return null;
+        }
+        return ((OxlaBinaryOperation.OxlaBinaryOperator) op).apply(new OxlaConstant[]{leftValue, rightValue});
+
+    }
+
+    public static class OxlaBinaryOperator extends OxlaOperator {
+        private final OxlaApplyFunction applyFunction;
+
+        public OxlaBinaryOperator(String textRepresentation, OxlaTypeOverload overload, OxlaApplyFunction applyFunction) {
+            super(textRepresentation, overload);
+            this.applyFunction = applyFunction;
+        }
+
+        public OxlaConstant apply(OxlaConstant[] constants) {
+            if (constants.length != 2) {
+                throw new AssertionError(String.format("OxlaUnaryBinaryOperation::apply* failed: expected 2 arguments, but got %d", constants.length));
+            }
+            return applyFunction.apply(constants);
+        }
+    }
+
+    public static final List<OxlaOperator> COMPARISON = List.of(
+            // Less
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INTERVAL}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            new OxlaBinaryOperator("<", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLess),
+            // Less Equal
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INTERVAL}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            new OxlaBinaryOperator("<=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyLessEqual),
+            // Not Equal
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INTERVAL}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            new OxlaBinaryOperator("!=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyNotEqual),
+            // Equal
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INTERVAL}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            new OxlaBinaryOperator("=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyEqual),
+            // Greater
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INTERVAL}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            new OxlaBinaryOperator(">", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreater),
+            // Greater Equal
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INTERVAL}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.DATE}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMP}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual),
+            new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual)
+    );
+
+    private static OxlaConstant applyLess(OxlaConstant[] constants) {
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        throw new AssertionError(String.format("OxlaBinaryOperation::applyLess failed: %s < %s", left.getClass(), right.getClass()));
+    }
+
+    private static OxlaConstant applyLessEqual(OxlaConstant[] constants) {
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        throw new AssertionError(String.format("OxlaBinaryOperation::applyLessEqual failed: %s < %s", left.getClass(), right.getClass()));
+    }
+
+    private static OxlaConstant applyNotEqual(OxlaConstant[] constants) {
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        throw new AssertionError(String.format("OxlaBinaryOperation::applyNotEqual failed: %s < %s", left.getClass(), right.getClass()));
+    }
+
+    private static OxlaConstant applyEqual(OxlaConstant[] constants) {
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        throw new AssertionError(String.format("OxlaBinaryOperation::applyEqual failed: %s < %s", left.getClass(), right.getClass()));
+    }
+
+    private static OxlaConstant applyGreater(OxlaConstant[] constants) {
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        throw new AssertionError(String.format("OxlaBinaryOperation::applyGreater failed: %s < %s", left.getClass(), right.getClass()));
+    }
+
+    private static OxlaConstant applyGreaterEqual(OxlaConstant[] constants) {
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        throw new AssertionError(String.format("OxlaBinaryOperation::applyGreaterEqual failed: %s < %s", left.getClass(), right.getClass()));
     }
 }

--- a/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
@@ -1,5 +1,6 @@
 package sqlancer.oxla.ast;
 
+import sqlancer.IgnoreMeException;
 import sqlancer.common.ast.BinaryOperatorNode;
 import sqlancer.common.ast.newast.NewBinaryOperatorNode;
 import sqlancer.oxla.schema.OxlaDataType;
@@ -33,6 +34,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
         }
 
         public OxlaConstant apply(OxlaConstant[] constants) {
+            if (applyFunction == null) {
+                // NOTE: `applyFunction` is not implemented, thus PQS oracle should ignore this operator.
+                throw new IgnoreMeException();
+            }
             if (constants.length != 2) {
                 throw new AssertionError(String.format("OxlaUnaryBinaryOperation::apply* failed: expected 2 arguments, but got %d", constants.length));
             }
@@ -163,7 +168,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
             new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual)
     );
 
-    public static final List<OxlaOperator> LOGICAL = List.of();
+    public static final List<OxlaOperator> LOGIC = List.of(
+            new OxlaBinaryOperator("AND", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN}, OxlaDataType.BOOLEAN), null),
+            new OxlaBinaryOperator("OR", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN}, OxlaDataType.BOOLEAN), null)
+    );
 
     public static final List<OxlaOperator> ARITHMETIC = List.of(
             // Addition
@@ -241,7 +249,43 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
             new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyMod),
             new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMod),
             new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyMod)
+    );
 
+    public static final List<OxlaOperator> REGEX = List.of(
+            new OxlaBinaryOperator("!~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
+            new OxlaBinaryOperator("!~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
+            new OxlaBinaryOperator("!~~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
+            new OxlaBinaryOperator("!~~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.TEXT), null),
+            new OxlaBinaryOperator("!~~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
+            new OxlaBinaryOperator("!~~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.TEXT), null),
+            new OxlaBinaryOperator("~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
+            new OxlaBinaryOperator("~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
+            new OxlaBinaryOperator("~~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
+            new OxlaBinaryOperator("~~", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.TEXT), null),
+            new OxlaBinaryOperator("~~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.BOOLEAN), null),
+            new OxlaBinaryOperator("~~*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TEXT, OxlaDataType.TEXT}, OxlaDataType.TEXT), null)
+    );
+
+    public static final List<OxlaOperator> BINARY = List.of(
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), null),
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), null),
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null),
+            new OxlaBinaryOperator("&", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
+            new OxlaBinaryOperator("&", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null),
+            new OxlaBinaryOperator("|", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
+            new OxlaBinaryOperator("|", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null),
+            new OxlaBinaryOperator("#", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
+            new OxlaBinaryOperator("#", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null)
+    );
+
+    public static final List<OxlaOperator> MISC = List.of(
+            new OxlaBinaryOperator("AT TIME ZONE", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TEXT}, OxlaDataType.TIMESTAMPTZ), null),
+            new OxlaBinaryOperator("AT TIME ZONE", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TEXT}, OxlaDataType.TIMESTAMP), null),
+            new OxlaBinaryOperator("->", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.JSON, OxlaDataType.INT32}, OxlaDataType.JSON), null),
+            new OxlaBinaryOperator("->", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.JSON, OxlaDataType.TEXT}, OxlaDataType.JSON), null),
+            new OxlaBinaryOperator("->>", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.JSON, OxlaDataType.INT32}, OxlaDataType.TEXT), null),
+            new OxlaBinaryOperator("->>", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.JSON, OxlaDataType.TEXT}, OxlaDataType.TEXT), null)
     );
 
     private static OxlaConstant applyComparison(OxlaConstant[] constants, IntPredicate comparisonFunction) {

--- a/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
@@ -270,16 +270,16 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
     );
 
     public static final List<OxlaOperator> BINARY = List.of(
-            new OxlaBinaryOperator("#", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
-            new OxlaBinaryOperator("#", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null),
-            new OxlaBinaryOperator("&", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
-            new OxlaBinaryOperator("&", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null),
-            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), null),
-            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), null),
-            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
-            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null),
-            new OxlaBinaryOperator("|", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), null),
-            new OxlaBinaryOperator("|", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), null)
+            new OxlaBinaryOperator("#", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyBitXor),
+            new OxlaBinaryOperator("#", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyBitXor),
+            new OxlaBinaryOperator("&", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyBitAnd),
+            new OxlaBinaryOperator("&", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyBitAnd),
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyBitPower),
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyBitPower),
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyBitPower),
+            new OxlaBinaryOperator("^", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyBitPower),
+            new OxlaBinaryOperator("|", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyBitOr),
+            new OxlaBinaryOperator("|", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyBitOr)
     );
 
     public static final List<OxlaOperator> MISC = List.of(
@@ -378,5 +378,45 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
             return OxlaConstant.createFloat64Constant(((OxlaConstant.OxlaFloat64Constant) left).value % ((OxlaConstant.OxlaFloat64Constant) right).value);
         }
         throw new AssertionError(String.format("OxlaBinaryOperationOperation::applyMod failed: %s vs %s", left.getClass(), right.getClass()));
+    }
+
+    private static OxlaConstant applyBitXor(OxlaConstant[] constants) {
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value ^ ((OxlaConstant.OxlaIntegerConstant) right).value);
+        }
+        throw new AssertionError(String.format("OxlaBinaryOperationOperation::applyBitXor failed: %s vs %s", constants[0].getClass(), constants[1].getClass()));
+    }
+
+    private static OxlaConstant applyBitAnd(OxlaConstant[] constants) {
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value & ((OxlaConstant.OxlaIntegerConstant) right).value);
+        }
+        throw new AssertionError(String.format("OxlaBinaryOperationOperation::applyBitAnd failed: %s vs %s", constants[0].getClass(), constants[1].getClass()));
+    }
+
+    private static OxlaConstant applyBitPower(OxlaConstant[] constants) {
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value & ((OxlaConstant.OxlaIntegerConstant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
+            return OxlaConstant.createFloat32Constant((float) Math.pow(((OxlaConstant.OxlaFloat32Constant) left).value, ((OxlaConstant.OxlaFloat32Constant) right).value));
+        } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
+            return OxlaConstant.createFloat64Constant(Math.pow(((OxlaConstant.OxlaFloat64Constant) left).value, ((OxlaConstant.OxlaFloat64Constant) right).value));
+        }
+        throw new AssertionError(String.format("OxlaBinaryOperationOperation::applyBitPower failed: %s vs %s", constants[0].getClass(), constants[1].getClass()));
+    }
+
+    private static OxlaConstant applyBitOr(OxlaConstant[] constants) {
+        final OxlaConstant left = constants[0];
+        final OxlaConstant right = constants[1];
+        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value | ((OxlaConstant.OxlaIntegerConstant) right).value);
+        }
+        throw new AssertionError(String.format("OxlaBinaryOperationOperation::applyBitOr failed: %s vs %s", constants[0].getClass(), constants[1].getClass()));
     }
 }

--- a/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
@@ -5,6 +5,7 @@ import sqlancer.common.ast.newast.NewBinaryOperatorNode;
 import sqlancer.oxla.schema.OxlaDataType;
 
 import java.util.List;
+import java.util.function.IntPredicate;
 
 public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
         implements OxlaExpression {
@@ -162,39 +163,34 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
             new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual)
     );
 
+    private static OxlaConstant applyComparison(OxlaConstant[] constants, IntPredicate comparisonFunction) {
+        if (constants[0] instanceof OxlaConstant.OxlaNullConstant || constants[1] instanceof OxlaConstant.OxlaNullConstant) {
+            return OxlaConstant.createNullConstant();
+        }
+        return OxlaConstant.createBooleanConstant(comparisonFunction.test(constants[0].compareTo(constants[1])));
+    }
+
     private static OxlaConstant applyLess(OxlaConstant[] constants) {
-        final OxlaConstant left = constants[0];
-        final OxlaConstant right = constants[1];
-        throw new AssertionError(String.format("OxlaBinaryOperation::applyLess failed: %s < %s", left.getClass(), right.getClass()));
+        return applyComparison(constants, (a) -> a < 0);
     }
 
     private static OxlaConstant applyLessEqual(OxlaConstant[] constants) {
-        final OxlaConstant left = constants[0];
-        final OxlaConstant right = constants[1];
-        throw new AssertionError(String.format("OxlaBinaryOperation::applyLessEqual failed: %s < %s", left.getClass(), right.getClass()));
+        return applyComparison(constants, (a) -> a <= 0);
     }
 
     private static OxlaConstant applyNotEqual(OxlaConstant[] constants) {
-        final OxlaConstant left = constants[0];
-        final OxlaConstant right = constants[1];
-        throw new AssertionError(String.format("OxlaBinaryOperation::applyNotEqual failed: %s < %s", left.getClass(), right.getClass()));
+        return applyComparison(constants, (a) -> a != 0);
     }
 
     private static OxlaConstant applyEqual(OxlaConstant[] constants) {
-        final OxlaConstant left = constants[0];
-        final OxlaConstant right = constants[1];
-        throw new AssertionError(String.format("OxlaBinaryOperation::applyEqual failed: %s < %s", left.getClass(), right.getClass()));
+        return applyComparison(constants, (a) -> a == 0);
     }
 
     private static OxlaConstant applyGreater(OxlaConstant[] constants) {
-        final OxlaConstant left = constants[0];
-        final OxlaConstant right = constants[1];
-        throw new AssertionError(String.format("OxlaBinaryOperation::applyGreater failed: %s < %s", left.getClass(), right.getClass()));
+        return applyComparison(constants, (a) -> a > 0);
     }
 
     private static OxlaConstant applyGreaterEqual(OxlaConstant[] constants) {
-        final OxlaConstant left = constants[0];
-        final OxlaConstant right = constants[1];
-        throw new AssertionError(String.format("OxlaBinaryOperation::applyGreaterEqual failed: %s < %s", left.getClass(), right.getClass()));
+        return applyComparison(constants, (a) -> a >= 0);
     }
 }

--- a/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
@@ -163,6 +163,87 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
             new OxlaBinaryOperator(">=", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.BOOLEAN), OxlaBinaryOperation::applyGreaterEqual)
     );
 
+    public static final List<OxlaOperator> LOGICAL = List.of();
+
+    public static final List<OxlaOperator> ARITHMETIC = List.of(
+            // Addition
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.INT32}, OxlaDataType.DATE), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.TIME}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.DATE}, OxlaDataType.DATE), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.DATE}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.TIMESTAMP}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.TIMESTAMPTZ), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMPTZ), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.DATE}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.INTERVAL}, OxlaDataType.TIME), OxlaBinaryOperation::applyAdd),
+            new OxlaBinaryOperator("+", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.TIME}, OxlaDataType.TIME), OxlaBinaryOperation::applyAdd),
+            // Subtraction
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.DATE}, OxlaDataType.INT32), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.INT32}, OxlaDataType.DATE), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMP), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMP, OxlaDataType.TIMESTAMP}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.INTERVAL}, OxlaDataType.TIMESTAMPTZ), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMPTZ}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.INTERVAL}, OxlaDataType.TIME), OxlaBinaryOperation::applySub),
+            new OxlaBinaryOperator("-", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.TIME, OxlaDataType.TIME}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applySub),
+            // Multiplication
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.INTERVAL}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT32}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.FLOAT32}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT64}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.FLOAT64}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMul),
+            new OxlaBinaryOperator("*", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyMul),
+            // Division
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT32}, OxlaDataType.INT64), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT32}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.INT64}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.FLOAT32}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INTERVAL, OxlaDataType.FLOAT64}, OxlaDataType.INTERVAL), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyDiv),
+            new OxlaBinaryOperator("/", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyDiv),
+            // Modulus
+            new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT64, OxlaDataType.INT64}, OxlaDataType.INT64), OxlaBinaryOperation::applyMod),
+            new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.INT32, OxlaDataType.INT32}, OxlaDataType.INT32), OxlaBinaryOperation::applyMod),
+            new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64), OxlaBinaryOperation::applyMod),
+            new OxlaBinaryOperator("%", new OxlaTypeOverload(new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32), OxlaBinaryOperation::applyMod)
+
+    );
+
     private static OxlaConstant applyComparison(OxlaConstant[] constants, IntPredicate comparisonFunction) {
         if (constants[0] instanceof OxlaConstant.OxlaNullConstant || constants[1] instanceof OxlaConstant.OxlaNullConstant) {
             return OxlaConstant.createNullConstant();
@@ -192,5 +273,25 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
 
     private static OxlaConstant applyGreaterEqual(OxlaConstant[] constants) {
         return applyComparison(constants, (a) -> a >= 0);
+    }
+
+    private static OxlaConstant applyAdd(OxlaConstant[] constants) {
+        throw new AssertionError("not implemented yet.");
+    }
+
+    private static OxlaConstant applySub(OxlaConstant[] constants) {
+        throw new AssertionError("not implemented yet.");
+    }
+
+    private static OxlaConstant applyMul(OxlaConstant[] constants) {
+        throw new AssertionError("not implemented yet.");
+    }
+
+    private static OxlaConstant applyDiv(OxlaConstant[] constants) {
+        throw new AssertionError("not implemented yet.");
+    }
+
+    private static OxlaConstant applyMod(OxlaConstant[] constants) {
+        throw new AssertionError("not implemented yet.");
     }
 }

--- a/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
@@ -64,7 +64,6 @@ public class OxlaUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<OxlaExp
             new OxlaUnaryPrefixOperator("||/", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64), OxlaUnaryPrefixOperation::applyCbrt),
             new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.INT32, OxlaDataType.INT32), OxlaUnaryPrefixOperation::applyBitNot),
             new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.INT64), OxlaUnaryPrefixOperation::applyBitNot)
-//            new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.TEXT, OxlaDataType.TEXT)) // FIXME Generate only for REGEXes.
     );
     public static final OxlaOperator NOT = ALL.get(13);
 

--- a/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
@@ -5,7 +5,6 @@ import sqlancer.common.ast.newast.NewUnaryPrefixOperatorNode;
 import sqlancer.oxla.schema.OxlaDataType;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class OxlaUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<OxlaExpression>
         implements OxlaExpression {
@@ -57,6 +56,7 @@ public class OxlaUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<OxlaExp
             new OxlaUnaryPrefixOperator("@", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64), OxlaUnaryPrefixOperation::applyAbs),
             new OxlaUnaryPrefixOperator("@", new OxlaTypeOverload(OxlaDataType.INT32, OxlaDataType.INT32), OxlaUnaryPrefixOperation::applyAbs),
             new OxlaUnaryPrefixOperator("@", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.INT64), OxlaUnaryPrefixOperation::applyAbs),
+            new OxlaUnaryPrefixOperator("!", new OxlaTypeOverload(OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN), OxlaUnaryPrefixOperation::applyNot),
             new OxlaUnaryPrefixOperator("NOT", new OxlaTypeOverload(OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN), OxlaUnaryPrefixOperation::applyNot),
             new OxlaUnaryPrefixOperator("|/", new OxlaTypeOverload(OxlaDataType.FLOAT32, OxlaDataType.FLOAT64), OxlaUnaryPrefixOperation::applySqrt),
             new OxlaUnaryPrefixOperator("|/", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64), OxlaUnaryPrefixOperation::applySqrt),
@@ -66,12 +66,6 @@ public class OxlaUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<OxlaExp
             new OxlaUnaryPrefixOperator("~", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.INT64), OxlaUnaryPrefixOperation::applyBitNot)
     );
     public static final OxlaOperator NOT = ALL.get(13);
-
-    public static List<OxlaOperator> getForType(OxlaDataType returnType) {
-        return ALL.stream()
-                .filter(op -> (op.overload.returnType == returnType))
-                .collect(Collectors.toList());
-    }
 
     private static OxlaConstant applyPlus(OxlaConstant[] constants) {
         return constants[0]; // No-op.

--- a/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
@@ -56,7 +56,6 @@ public class OxlaUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<OxlaExp
             new OxlaUnaryPrefixOperator("@", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64), OxlaUnaryPrefixOperation::applyAbs),
             new OxlaUnaryPrefixOperator("@", new OxlaTypeOverload(OxlaDataType.INT32, OxlaDataType.INT32), OxlaUnaryPrefixOperation::applyAbs),
             new OxlaUnaryPrefixOperator("@", new OxlaTypeOverload(OxlaDataType.INT64, OxlaDataType.INT64), OxlaUnaryPrefixOperation::applyAbs),
-            new OxlaUnaryPrefixOperator("!", new OxlaTypeOverload(OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN), OxlaUnaryPrefixOperation::applyNot),
             new OxlaUnaryPrefixOperator("NOT", new OxlaTypeOverload(OxlaDataType.BOOLEAN, OxlaDataType.BOOLEAN), OxlaUnaryPrefixOperation::applyNot),
             new OxlaUnaryPrefixOperator("|/", new OxlaTypeOverload(OxlaDataType.FLOAT32, OxlaDataType.FLOAT64), OxlaUnaryPrefixOperation::applySqrt),
             new OxlaUnaryPrefixOperator("|/", new OxlaTypeOverload(OxlaDataType.FLOAT64, OxlaDataType.FLOAT64), OxlaUnaryPrefixOperation::applySqrt),

--- a/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
+++ b/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
@@ -20,7 +20,14 @@ import java.util.stream.Stream;
 public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpression, OxlaColumn, OxlaDataType>
         implements NoRECGenerator<OxlaSelect, OxlaJoin, OxlaExpression, OxlaTable, OxlaColumn> {
     private enum ExpressionType {
-        BINARY_ARITHMETIC_OPERATOR, BINARY_COMPARISON_OPERATOR, BINARY_LOGIC_OPERATOR, UNARY_PREFIX_OPERATOR, UNARY_POSTFIX_OPERATOR;
+        BINARY_ARITHMETIC_OPERATOR,
+        BINARY_BINARY_OPERATOR,
+        BINARY_COMPARISON_OPERATOR,
+        BINARY_LOGIC_OPERATOR,
+        BINARY_MISC_OPERATOR,
+        BINARY_REGEX_OPERATOR,
+        UNARY_PREFIX_OPERATOR,
+        UNARY_POSTFIX_OPERATOR;
 
         public static ExpressionType getRandom() {
             return Randomly.fromOptions(values());
@@ -70,7 +77,13 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
             case BINARY_COMPARISON_OPERATOR:
                 return generateBinaryOperator(OxlaBinaryOperation.COMPARISON, wantReturnType, depth);
             case BINARY_LOGIC_OPERATOR:
-                return generateBinaryOperator(OxlaBinaryOperation.LOGICAL, wantReturnType, depth);
+                return generateBinaryOperator(OxlaBinaryOperation.LOGIC, wantReturnType, depth);
+            case BINARY_REGEX_OPERATOR:
+                return generateBinaryOperator(OxlaBinaryOperation.REGEX, wantReturnType, depth);
+            case BINARY_BINARY_OPERATOR:
+                return generateBinaryOperator(OxlaBinaryOperation.BINARY, wantReturnType, depth);
+            case BINARY_MISC_OPERATOR:
+                return generateBinaryOperator(OxlaBinaryOperation.MISC, wantReturnType, depth);
             default:
                 throw new AssertionError(expressionType);
         }

--- a/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
+++ b/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
@@ -65,11 +65,11 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
             case UNARY_POSTFIX_OPERATOR:
                 return generateUnaryOperator(OxlaUnaryPostfixOperation::new, OxlaUnaryPostfixOperation.ALL, wantReturnType, depth);
             case BINARY_ARITHMETIC_OPERATOR:
-                return generateBinaryOperator(OxlaBinaryOperation::new, OxlaBinaryOperation.ARITHMETIC, wantReturnType, depth);
+                return generateBinaryOperator(OxlaBinaryOperation.ARITHMETIC, wantReturnType, depth);
             case BINARY_COMPARISON_OPERATOR:
-                return generateBinaryOperator(OxlaBinaryOperation::new, OxlaBinaryOperation.COMPARISON, wantReturnType, depth);
+                return generateBinaryOperator(OxlaBinaryOperation.COMPARISON, wantReturnType, depth);
             case BINARY_LOGIC_OPERATOR:
-                return generateBinaryOperator(OxlaBinaryOperation::new, OxlaBinaryOperation.LOGICAL, wantReturnType, depth);
+                return generateBinaryOperator(OxlaBinaryOperation.LOGICAL, wantReturnType, depth);
             default:
                 throw new AssertionError(expressionType);
         }
@@ -204,12 +204,7 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
         return factory.create(inputExpression, randomOperator);
     }
 
-    @FunctionalInterface
-    interface OxlaBinaryOperatorFactory {
-        OxlaExpression create(OxlaExpression left, OxlaExpression right, OxlaOperator op);
-    }
-
-    private OxlaExpression generateBinaryOperator(OxlaBinaryOperatorFactory factory, List<OxlaOperator> operators, OxlaDataType wantReturnType, int depth) {
+    private OxlaExpression generateBinaryOperator(List<OxlaOperator> operators, OxlaDataType wantReturnType, int depth) {
         List<OxlaOperator> validOperators = new ArrayList<>(operators);
         validOperators.removeIf(operator -> operator.overload.returnType != wantReturnType);
 
@@ -221,6 +216,6 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
         OxlaOperator randomOperator = Randomly.fromList(validOperators);
         OxlaExpression left = generateExpression(randomOperator.overload.inputTypes[0], depth + 1);
         OxlaExpression right = generateExpression(randomOperator.overload.inputTypes[1], depth + 1);
-        return factory.create(left, right, randomOperator);
+        return new OxlaBinaryOperation(left, right, randomOperator);
     }
 }

--- a/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
+++ b/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpression, OxlaColumn, OxlaDataType>
         implements NoRECGenerator<OxlaSelect, OxlaJoin, OxlaExpression, OxlaTable, OxlaColumn> {
     private enum ExpressionType {
-        BINARY_COMPARISON, UNARY_PREFIX, UNARY_POSTFIX;
+        BINARY_ARITHMETIC_OPERATOR, BINARY_COMPARISON_OPERATOR, BINARY_LOGIC_OPERATOR, UNARY_PREFIX_OPERATOR, UNARY_POSTFIX_OPERATOR;
 
         public static ExpressionType getRandom() {
             return Randomly.fromOptions(values());
@@ -60,12 +60,16 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
 
         ExpressionType expressionType = ExpressionType.getRandom();
         switch (expressionType) {
-            case UNARY_PREFIX:
+            case UNARY_PREFIX_OPERATOR:
                 return generateUnaryOperator(OxlaUnaryPrefixOperation::new, OxlaUnaryPrefixOperation.ALL, wantReturnType, depth);
-            case UNARY_POSTFIX:
+            case UNARY_POSTFIX_OPERATOR:
                 return generateUnaryOperator(OxlaUnaryPostfixOperation::new, OxlaUnaryPostfixOperation.ALL, wantReturnType, depth);
-            case BINARY_COMPARISON:
+            case BINARY_ARITHMETIC_OPERATOR:
+                return generateBinaryOperator(OxlaBinaryOperation::new, OxlaBinaryOperation.ARITHMETIC, wantReturnType, depth);
+            case BINARY_COMPARISON_OPERATOR:
                 return generateBinaryOperator(OxlaBinaryOperation::new, OxlaBinaryOperation.COMPARISON, wantReturnType, depth);
+            case BINARY_LOGIC_OPERATOR:
+                return generateBinaryOperator(OxlaBinaryOperation::new, OxlaBinaryOperation.LOGICAL, wantReturnType, depth);
             default:
                 throw new AssertionError(expressionType);
         }

--- a/src/sqlancer/oxla/oracle/OxlaFuzzer.java
+++ b/src/sqlancer/oxla/oracle/OxlaFuzzer.java
@@ -1,7 +1,9 @@
 package sqlancer.oxla.oracle;
 
+import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.oxla.OxlaGlobalState;
 import sqlancer.oxla.ast.OxlaExpression;
@@ -18,10 +20,12 @@ import java.util.stream.Collectors;
 public class OxlaFuzzer implements TestOracle<OxlaGlobalState> {
     private final OxlaGlobalState globalState;
     private final OxlaExpressionGenerator generator;
+    private final ExpectedErrors errors;
 
-    public OxlaFuzzer(OxlaGlobalState globalState) {
+    public OxlaFuzzer(OxlaGlobalState globalState, ExpectedErrors errors) {
         this.globalState = globalState;
         this.generator = new OxlaExpressionGenerator(globalState);
+        this.errors = errors;
     }
 
     @Override
@@ -31,7 +35,9 @@ public class OxlaFuzzer implements TestOracle<OxlaGlobalState> {
             globalState.executeStatement(query);
             globalState.getManager().incrementSelectQueryCount();
         } catch (Error e) {
-            // NOTE
+            if (errors.errorIsExpected(e.getMessage())) {
+                throw new IgnoreMeException();
+            }
             throw new AssertionError(e);
         }
     }

--- a/src/sqlancer/oxla/oracle/OxlaFuzzer.java
+++ b/src/sqlancer/oxla/oracle/OxlaFuzzer.java
@@ -88,6 +88,6 @@ public class OxlaFuzzer implements TestOracle<OxlaGlobalState> {
         if (Randomly.getBoolean()) {
             select.setOffsetClause(generator.generateConstant(Randomly.fromOptions(OxlaDataType.NUMERIC)));
         }
-        return new SQLQueryAdapter(select.toString());
+        return new SQLQueryAdapter(select.toString(), this.errors);
     }
 }

--- a/src/sqlancer/oxla/oracle/OxlaPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaPivotedQuerySynthesisOracle.java
@@ -136,7 +136,7 @@ public class OxlaPivotedQuerySynthesisOracle extends PivotedQuerySynthesisBase<O
             select.setOffsetClause(OxlaConstant.createInt32Constant(0));
         }
 
-        return new SQLQueryAdapter(OxlaToStringVisitor.asString(select));
+        return new SQLQueryAdapter(OxlaToStringVisitor.asString(select), errors);
     }
 
     @Override

--- a/src/sqlancer/oxla/oracle/OxlaPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaPivotedQuerySynthesisOracle.java
@@ -28,6 +28,7 @@ public class OxlaPivotedQuerySynthesisOracle extends PivotedQuerySynthesisBase<O
         errors.addAll(OxlaCommon.SYNTAX_ERRORS);
         errors.addAllRegexes(OxlaCommon.SYNTAX_REGEX_ERRORS);
         errors.addAll(OxlaCommon.JOIN_ERRORS);
+        errors.addAllRegexes(OxlaCommon.JOIN_REGEX_ERRORS);
         errors.addAll(OxlaCommon.GROUP_BY_ERRORS);
         errors.addAllRegexes(OxlaCommon.GROUP_BY_REGEX_ERRORS);
         errors.addAll(OxlaCommon.ORDER_BY_ERRORS);


### PR DESCRIPTION
Adds overloads for all possible operators in Oxla (that handle basic types) - implements `apply` function for a significant part of them.
Adds `compareTo(OxlaDataType)` method to `OxlaConstant` and implements it for each defined type.
Adds more `ExpectedErrors` that can be returned by the database.
Adds `bugOxla????` switches that disable certain problematic queries (mostly causing crashes).
Instantiates the operators in `OxlaExpressionGenerator`.
Refactors `OxlaOracleFactory` a bit to easily add `ExpectedErrors` to oracles.
Refactors `OxlaExpressionGenerator` to simplify operator creation logic.
Fixes `OxlaFuzzer` and `OxlaPivotedQuerySynthesis` oracle(s) ignoring certain expected errors.


Bugs caught by this PR:
https://oxla.atlassian.net/browse/OXLA-8328
https://oxla.atlassian.net/browse/OXLA-8329
https://oxla.atlassian.net/browse/OXLA-8330
https://oxla.atlassian.net/browse/OXLA-8332
https://oxla.atlassian.net/browse/OXLA-8338