### PR TITLE
OXLA-8190 Implement `Ternary Logic Partitioning (TLP)` oracle for Oxla.

### DIFF
--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -166,7 +166,7 @@ public final class ComparatorHelper {
             ExpectedErrors errors) throws SQLException {
         String unionString;
         if (asUnion) {
-            unionString = " (" + firstQueryString + ") UNION (" + secondQueryString + ") UNION (" + thirdQueryString + ")";
+            unionString = "(" + firstQueryString + ") UNION (" + secondQueryString + ") UNION (" + thirdQueryString + ")";
         } else {
             unionString = "SELECT DISTINCT * FROM ((" + firstQueryString + ") UNION ALL (" + secondQueryString
                     + ") UNION ALL (" + thirdQueryString + "))";

--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -166,10 +166,10 @@ public final class ComparatorHelper {
             ExpectedErrors errors) throws SQLException {
         String unionString;
         if (asUnion) {
-            unionString = firstQueryString + " UNION " + secondQueryString + " UNION " + thirdQueryString;
+            unionString = " (" + firstQueryString + ") UNION (" + secondQueryString + ") UNION (" + thirdQueryString + ")";
         } else {
-            unionString = "SELECT DISTINCT * FROM (" + firstQueryString + " UNION ALL " + secondQueryString
-                    + " UNION ALL " + thirdQueryString + ")";
+            unionString = "SELECT DISTINCT * FROM ((" + firstQueryString + ") UNION ALL (" + secondQueryString
+                    + ") UNION ALL (" + thirdQueryString + "))";
         }
         List<String> secondResultSet;
         combinedString.add(unionString);

--- a/src/sqlancer/common/query/ExpectedErrors.java
+++ b/src/sqlancer/common/query/ExpectedErrors.java
@@ -50,6 +50,15 @@ public class ExpectedErrors {
         return this;
     }
 
+    public ExpectedErrors addAll(ExpectedErrors appendErrors) {
+        if (appendErrors == null) {
+            throw new IllegalArgumentException();
+        }
+        errors.addAll(appendErrors.errors);
+        regexes.addAll(appendErrors.regexes);
+        return this;
+    }
+
     public ExpectedErrors addAll(Collection<String> list) {
         if (list == null) {
             throw new IllegalArgumentException();

--- a/src/sqlancer/oxla/OxlaBugs.java
+++ b/src/sqlancer/oxla/OxlaBugs.java
@@ -39,4 +39,8 @@ public final class OxlaBugs {
     /// See: https://oxla.atlassian.net/browse/OXLA-8350
     /// 'pg_*' functions that accept INT4 do not work with INT8.
     public static boolean bugOxla8350 = true;
+
+    /// See: https://oxla.atlassian.net/browse/OXLA-8364
+    /// `timestamp_trunc` returns invalid parsing errors for numeric params.
+    public static boolean bugOxla8364 = true;
 }

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -62,7 +62,8 @@ public class OxlaCommon {
             Pattern.compile("unit \"[^\"]*\" not recognized for type (.+)"),
             Pattern.compile("database \"[^\"]*\" does not exist"),
             Pattern.compile("role \"[^\"]*\" does not exist"),
-            Pattern.compile("HAS_SCHEMA_PRIVILEGE function got unrecognized privilege type:\\s+\"[^\"]*\"")
+            Pattern.compile("HAS_SCHEMA_PRIVILEGE function got unrecognized privilege type:\\s+\"[^\"]*\""),
+            Pattern.compile("found multiple function overloads taking arguments from different type categories, when trying to match function\\s+(.+)")
     );
 
     public static List<String> bugErrors() {

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -51,7 +51,8 @@ public class OxlaCommon {
             "aggregate function calls cannot be nested",
             "expecting only literal for percentiles",
             "could not determine polymorphic type because input has type unknown",
-            "cannot get array length of a non-array"
+            "cannot get array length of a non-array",
+            "empty format provided"
     );
     public static final List<Pattern> EXPRESSION_REGEX_ERRORS = List.of(
             Pattern.compile("operator is not unique:\\s+(.+)"),
@@ -64,7 +65,8 @@ public class OxlaCommon {
             Pattern.compile("database \"[^\"]*\" does not exist"),
             Pattern.compile("role \"[^\"]*\" does not exist"),
             Pattern.compile("HAS_SCHEMA_PRIVILEGE function got unrecognized privilege type:\\s+\"[^\"]*\""),
-            Pattern.compile("found multiple function overloads taking arguments from different type categories, when trying to match function\\s+(.+)")
+            Pattern.compile("found multiple function overloads taking arguments from different type categories, when trying to match function\\s+(.+)"),
+            Pattern.compile("nrecognized privilege type:\\s+\"[^\"]*\"")
     );
 
     public static List<String> bugErrors() {

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -28,7 +28,8 @@ public class OxlaCommon {
             Pattern.compile("could not identify an ordering operator for type\\s+.*")
     );
     public static final List<String> GROUP_BY_ERRORS = List.of(
-            "non-integer constant in GROUP BY"
+            "non-integer constant in GROUP BY",
+            "'*' can be used only in the SELECT clause."
     );
     public static final List<Pattern> GROUP_BY_REGEX_ERRORS = List.of(
             Pattern.compile("GROUP BY position (\\d+) is not in select list"),
@@ -78,6 +79,7 @@ public class OxlaCommon {
         if (OxlaBugs.bugOxla8332) {
             list.add("std::get: wrong index for variant");
         }
+        list.add("is not supported"); // TODO TEMP
         return list;
     }
 

--- a/src/sqlancer/oxla/OxlaCommon.java
+++ b/src/sqlancer/oxla/OxlaCommon.java
@@ -33,7 +33,8 @@ public class OxlaCommon {
     );
     public static final List<Pattern> GROUP_BY_REGEX_ERRORS = List.of(
             Pattern.compile("GROUP BY position (\\d+) is not in select list"),
-            Pattern.compile("column \"[^\"]+\" must appear in the GROUP BY clause or be used in an aggregate function")
+            Pattern.compile("column \"[^\"]+\" must appear in the GROUP BY clause or be used in an aggregate function"),
+            Pattern.compile("could not identify an equality operator for type\\s+(.*)")
     );
     public static final List<String> ORDER_BY_ERRORS = List.of(
             "non-integer constant in ORDER BY"

--- a/src/sqlancer/oxla/OxlaOracleFactory.java
+++ b/src/sqlancer/oxla/OxlaOracleFactory.java
@@ -74,7 +74,10 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
             oracles.add(AGGREGATE.create(globalState));
             oracles.add(DISTINCT.create(globalState));
             oracles.add(GROUP_BY.create(globalState));
-            oracles.add(HAVING.create(globalState));
+            // FIXME Cannot test HAVING oracle, because SQLancer generates incorrect testing clauses;
+            //       They ignore possible duplicate values and trigger false-positive cardinality errors.
+            //       Enable after this is supported correctly (https://github.com/sqlancer/sqlancer/issues/1048)
+            //       oracles.add(HAVING.create(globalState));
             oracles.add(WHERE.create(globalState));
             oracles.add(WHERE_EXTENDED.create(globalState));
             return new CompositeTestOracle<>(oracles, globalState);

--- a/src/sqlancer/oxla/OxlaOracleFactory.java
+++ b/src/sqlancer/oxla/OxlaOracleFactory.java
@@ -5,8 +5,7 @@ import sqlancer.common.oracle.CompositeTestOracle;
 import sqlancer.common.oracle.NoRECOracle;
 import sqlancer.common.oracle.TestOracle;
 import sqlancer.oxla.gen.OxlaExpressionGenerator;
-import sqlancer.oxla.oracle.OxlaFuzzer;
-import sqlancer.oxla.oracle.OxlaPivotedQuerySynthesisOracle;
+import sqlancer.oxla.oracle.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +21,7 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
     PQS {
         @Override
         public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
-            return new OxlaPivotedQuerySynthesisOracle(globalState);
+            return new OxlaPivotedQuerySynthesisOracle(globalState, OxlaCommon.ALL_ERRORS);
         }
 
         @Override
@@ -30,11 +29,53 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
             return true;
         }
     },
+    AGGREGATE {
+        @Override
+        public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
+            return new OxlaTLPAggregateOracle(globalState, OxlaCommon.ALL_ERRORS);
+        }
+    },
+    DISTINCT {
+        @Override
+        public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
+            return new OxlaTLPDistinctOracle(globalState);
+        }
+    },
+    GROUP_BY {
+        @Override
+        public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
+            return new OxlaTLPGroupByOracle(globalState);
+        }
+    },
+    HAVING {
+        @Override
+        public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
+            return new OxlaTLPHavingOracle(globalState);
+        }
+    },
+    WHERE {
+        @Override
+        public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
+            OxlaExpressionGenerator generator = new OxlaExpressionGenerator(globalState);
+            return new NoRECOracle<>(globalState, generator, OxlaCommon.ALL_ERRORS);
+        }
+    },
+    WHERE_EXTENDED {
+        @Override
+        public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
+            return new OxlaTLPWhereExtendedOracle(globalState);
+        }
+    },
     QUERY_PARTITIONING {
         @Override
         public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
             List<TestOracle<OxlaGlobalState>> oracles = new ArrayList<>();
-            // TODO
+            oracles.add(AGGREGATE.create(globalState));
+            oracles.add(DISTINCT.create(globalState));
+            oracles.add(GROUP_BY.create(globalState));
+            oracles.add(HAVING.create(globalState));
+            oracles.add(WHERE.create(globalState));
+            oracles.add(WHERE_EXTENDED.create(globalState));
             return new CompositeTestOracle<>(oracles, globalState);
         }
 

--- a/src/sqlancer/oxla/OxlaOracleFactory.java
+++ b/src/sqlancer/oxla/OxlaOracleFactory.java
@@ -64,7 +64,7 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
     WHERE_EXTENDED {
         @Override
         public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
-            return new OxlaTLPWhereExtendedOracle(globalState);
+            return new OxlaTLPWhereExtendedOracle(globalState, OxlaCommon.ALL_ERRORS);
         }
     },
     QUERY_PARTITIONING {

--- a/src/sqlancer/oxla/OxlaOracleFactory.java
+++ b/src/sqlancer/oxla/OxlaOracleFactory.java
@@ -74,12 +74,13 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
             oracles.add(AGGREGATE.create(globalState));
             oracles.add(DISTINCT.create(globalState));
             oracles.add(GROUP_BY.create(globalState));
-            // FIXME Cannot test HAVING oracle, because SQLancer generates incorrect testing clauses;
+            // FIXME Cannot test HAVING oracle, because SQLancer itself generates incorrect testing clauses;
             //       They ignore possible duplicate values and trigger false-positive cardinality errors.
-            //       Enable after this is supported correctly (https://github.com/sqlancer/sqlancer/issues/1048)
             //       oracles.add(HAVING.create(globalState));
             oracles.add(WHERE.create(globalState));
-            oracles.add(WHERE_EXTENDED.create(globalState));
+            // FIXME Cannot test WHERE_EXTENDED oracle, because SQLancer itself generates incorrect testing clauses;
+            //       They ignore possible duplicate values and trigger false-positive cardinality errors.
+            //       oracles.add(WHERE_EXTENDED.create(globalState));
             return new CompositeTestOracle<>(oracles, globalState);
         }
 

--- a/src/sqlancer/oxla/OxlaOracleFactory.java
+++ b/src/sqlancer/oxla/OxlaOracleFactory.java
@@ -3,6 +3,7 @@ package sqlancer.oxla;
 import sqlancer.OracleFactory;
 import sqlancer.common.oracle.CompositeTestOracle;
 import sqlancer.common.oracle.NoRECOracle;
+import sqlancer.common.oracle.TLPWhereOracle;
 import sqlancer.common.oracle.TestOracle;
 import sqlancer.oxla.gen.OxlaExpressionGenerator;
 import sqlancer.oxla.oracle.*;
@@ -38,26 +39,26 @@ public enum OxlaOracleFactory implements OracleFactory<OxlaGlobalState> {
     DISTINCT {
         @Override
         public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
-            return new OxlaTLPDistinctOracle(globalState);
+            return new OxlaTLPDistinctOracle(globalState, OxlaCommon.ALL_ERRORS);
         }
     },
     GROUP_BY {
         @Override
         public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
-            return new OxlaTLPGroupByOracle(globalState);
+            return new OxlaTLPGroupByOracle(globalState, OxlaCommon.ALL_ERRORS);
         }
     },
     HAVING {
         @Override
         public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
-            return new OxlaTLPHavingOracle(globalState);
+            return new OxlaTLPHavingOracle(globalState, OxlaCommon.ALL_ERRORS);
         }
     },
     WHERE {
         @Override
         public TestOracle<OxlaGlobalState> create(OxlaGlobalState globalState) throws Exception {
             OxlaExpressionGenerator generator = new OxlaExpressionGenerator(globalState);
-            return new NoRECOracle<>(globalState, generator, OxlaCommon.ALL_ERRORS);
+            return new TLPWhereOracle<>(globalState, generator, OxlaCommon.ALL_ERRORS);
         }
     },
     WHERE_EXTENDED {

--- a/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaBinaryOperation.java
@@ -318,8 +318,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
     private static OxlaConstant applyAdd(OxlaConstant[] constants) {
         final OxlaConstant left = constants[0];
         final OxlaConstant right = constants[1];
-        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value + ((OxlaConstant.OxlaIntegerConstant) right).value);
+        if (left instanceof OxlaConstant.OxlaInt32Constant && right instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(((OxlaConstant.OxlaInt32Constant) left).value + ((OxlaConstant.OxlaInt32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaInt64Constant && right instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaInt64Constant) left).value + ((OxlaConstant.OxlaInt64Constant) right).value);
         } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
             return OxlaConstant.createFloat32Constant(((OxlaConstant.OxlaFloat32Constant) left).value + ((OxlaConstant.OxlaFloat32Constant) right).value);
         } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
@@ -331,8 +333,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
     private static OxlaConstant applySub(OxlaConstant[] constants) {
         final OxlaConstant left = constants[0];
         final OxlaConstant right = constants[1];
-        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value - ((OxlaConstant.OxlaIntegerConstant) right).value);
+        if (left instanceof OxlaConstant.OxlaInt32Constant && right instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(((OxlaConstant.OxlaInt32Constant) left).value - ((OxlaConstant.OxlaInt32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaInt64Constant && right instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaInt64Constant) left).value - ((OxlaConstant.OxlaInt64Constant) right).value);
         } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
             return OxlaConstant.createFloat32Constant(((OxlaConstant.OxlaFloat32Constant) left).value - ((OxlaConstant.OxlaFloat32Constant) right).value);
         } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
@@ -344,8 +348,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
     private static OxlaConstant applyMul(OxlaConstant[] constants) {
         final OxlaConstant left = constants[0];
         final OxlaConstant right = constants[1];
-        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value * ((OxlaConstant.OxlaIntegerConstant) right).value);
+        if (left instanceof OxlaConstant.OxlaInt32Constant && right instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(((OxlaConstant.OxlaInt32Constant) left).value * ((OxlaConstant.OxlaInt32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaInt64Constant && right instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaInt64Constant) left).value * ((OxlaConstant.OxlaInt64Constant) right).value);
         } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
             return OxlaConstant.createFloat32Constant(((OxlaConstant.OxlaFloat32Constant) left).value * ((OxlaConstant.OxlaFloat32Constant) right).value);
         } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
@@ -357,8 +363,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
     private static OxlaConstant applyDiv(OxlaConstant[] constants) {
         final OxlaConstant left = constants[0];
         final OxlaConstant right = constants[1];
-        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value / ((OxlaConstant.OxlaIntegerConstant) right).value);
+        if (left instanceof OxlaConstant.OxlaInt32Constant && right instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(((OxlaConstant.OxlaInt32Constant) left).value / ((OxlaConstant.OxlaInt32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaInt64Constant && right instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaInt64Constant) left).value / ((OxlaConstant.OxlaInt64Constant) right).value);
         } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
             return OxlaConstant.createFloat32Constant(((OxlaConstant.OxlaFloat32Constant) left).value / ((OxlaConstant.OxlaFloat32Constant) right).value);
         } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
@@ -370,8 +378,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
     private static OxlaConstant applyMod(OxlaConstant[] constants) {
         OxlaConstant left = constants[0];
         OxlaConstant right = constants[1];
-        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value % ((OxlaConstant.OxlaIntegerConstant) right).value);
+        if (left instanceof OxlaConstant.OxlaInt32Constant && right instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(((OxlaConstant.OxlaInt32Constant) left).value % ((OxlaConstant.OxlaInt32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaInt64Constant && right instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaInt64Constant) left).value % ((OxlaConstant.OxlaInt64Constant) right).value);
         } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
             return OxlaConstant.createFloat32Constant(((OxlaConstant.OxlaFloat32Constant) left).value % ((OxlaConstant.OxlaFloat32Constant) right).value);
         } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
@@ -383,8 +393,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
     private static OxlaConstant applyBitXor(OxlaConstant[] constants) {
         final OxlaConstant left = constants[0];
         final OxlaConstant right = constants[1];
-        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value ^ ((OxlaConstant.OxlaIntegerConstant) right).value);
+        if (left instanceof OxlaConstant.OxlaInt32Constant && right instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(((OxlaConstant.OxlaInt32Constant) left).value ^ ((OxlaConstant.OxlaInt32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaInt64Constant && right instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaInt64Constant) left).value ^ ((OxlaConstant.OxlaInt64Constant) right).value);
         }
         throw new AssertionError(String.format("OxlaBinaryOperationOperation::applyBitXor failed: %s vs %s", constants[0].getClass(), constants[1].getClass()));
     }
@@ -392,8 +404,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
     private static OxlaConstant applyBitAnd(OxlaConstant[] constants) {
         final OxlaConstant left = constants[0];
         final OxlaConstant right = constants[1];
-        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value & ((OxlaConstant.OxlaIntegerConstant) right).value);
+        if (left instanceof OxlaConstant.OxlaInt32Constant && right instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(((OxlaConstant.OxlaInt32Constant) left).value & ((OxlaConstant.OxlaInt32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaInt64Constant && right instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaInt64Constant) left).value & ((OxlaConstant.OxlaInt64Constant) right).value);
         }
         throw new AssertionError(String.format("OxlaBinaryOperationOperation::applyBitAnd failed: %s vs %s", constants[0].getClass(), constants[1].getClass()));
     }
@@ -401,8 +415,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
     private static OxlaConstant applyBitPower(OxlaConstant[] constants) {
         final OxlaConstant left = constants[0];
         final OxlaConstant right = constants[1];
-        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant((long) Math.pow(((OxlaConstant.OxlaIntegerConstant) left).value, ((OxlaConstant.OxlaIntegerConstant) right).value));
+        if (left instanceof OxlaConstant.OxlaInt32Constant && right instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant((int) Math.pow(((OxlaConstant.OxlaInt32Constant) left).value, ((OxlaConstant.OxlaInt32Constant) right).value));
+        } else if (left instanceof OxlaConstant.OxlaInt64Constant && right instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant((long) Math.pow(((OxlaConstant.OxlaInt64Constant) left).value, ((OxlaConstant.OxlaInt64Constant) right).value));
         } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
             return OxlaConstant.createFloat32Constant((float) Math.pow(((OxlaConstant.OxlaFloat32Constant) left).value, ((OxlaConstant.OxlaFloat32Constant) right).value));
         } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {
@@ -414,8 +430,10 @@ public class OxlaBinaryOperation extends NewBinaryOperatorNode<OxlaExpression>
     private static OxlaConstant applyBitOr(OxlaConstant[] constants) {
         final OxlaConstant left = constants[0];
         final OxlaConstant right = constants[1];
-        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaIntegerConstant) left).value | ((OxlaConstant.OxlaIntegerConstant) right).value);
+        if (left instanceof OxlaConstant.OxlaInt32Constant && right instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(((OxlaConstant.OxlaInt32Constant) left).value | ((OxlaConstant.OxlaInt32Constant) right).value);
+        } else if (left instanceof OxlaConstant.OxlaInt64Constant && right instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant(((OxlaConstant.OxlaInt64Constant) left).value | ((OxlaConstant.OxlaInt64Constant) right).value);
         }
         throw new AssertionError(String.format("OxlaBinaryOperationOperation::applyBitOr failed: %s vs %s", constants[0].getClass(), constants[1].getClass()));
     }

--- a/src/sqlancer/oxla/ast/OxlaConstant.java
+++ b/src/sqlancer/oxla/ast/OxlaConstant.java
@@ -90,11 +90,11 @@ public abstract class OxlaConstant implements OxlaExpression {
     }
 
     public static OxlaConstant createInt32Constant(int value) {
-        return new OxlaIntegerConstant(value);
+        return new OxlaInt32Constant(value);
     }
 
     public static OxlaConstant createInt64Constant(long value) {
-        return new OxlaIntegerConstant(value);
+        return new OxlaInt64Constant(value);
     }
 
     public static OxlaConstant createIntervalConstant(int months, int days, long microseconds) {
@@ -250,8 +250,10 @@ public abstract class OxlaConstant implements OxlaExpression {
 
         @Override
         public int compareTo(OxlaConstant toType) {
-            if (toType instanceof OxlaIntegerConstant) {
-                return Float.compare(this.value, ((OxlaIntegerConstant) toType).value);
+            if (toType instanceof OxlaInt32Constant) {
+                return Float.compare(this.value, ((OxlaInt32Constant) toType).value);
+            } else if (toType instanceof OxlaInt64Constant) {
+                return Float.compare(this.value, ((OxlaInt64Constant) toType).value);
             } else if (toType instanceof OxlaFloat32Constant) {
                 return Float.compare(this.value, ((OxlaFloat32Constant) toType).value);
             } else if (toType instanceof OxlaFloat64Constant) {
@@ -298,8 +300,10 @@ public abstract class OxlaConstant implements OxlaExpression {
 
         @Override
         public int compareTo(OxlaConstant toType) {
-            if (toType instanceof OxlaIntegerConstant) {
-                return Double.compare(this.value, ((OxlaIntegerConstant) toType).value);
+            if (toType instanceof OxlaInt32Constant) {
+                return Double.compare(this.value, ((OxlaInt32Constant) toType).value);
+            } else if (toType instanceof OxlaInt64Constant) {
+                return Double.compare(this.value, ((OxlaInt64Constant) toType).value);
             } else if (toType instanceof OxlaFloat32Constant) {
                 return Double.compare(this.value, ((OxlaFloat32Constant) toType).value);
             } else if (toType instanceof OxlaFloat64Constant) {
@@ -309,14 +313,10 @@ public abstract class OxlaConstant implements OxlaExpression {
         }
     }
 
-    public static class OxlaIntegerConstant extends OxlaConstant {
-        public final long value;
+    public static class OxlaInt32Constant extends OxlaConstant {
+        public final int value;
 
-        public OxlaIntegerConstant(long value) {
-            this.value = value;
-        }
-
-        public OxlaIntegerConstant(int value) {
+        public OxlaInt32Constant(int value) {
             this.value = value;
         }
 
@@ -335,6 +335,54 @@ public abstract class OxlaConstant implements OxlaExpression {
                 case FLOAT64:
                     return OxlaConstant.createFloat64Constant(value);
                 case INT32:
+                    return this;
+                case INT64:
+                    return OxlaConstant.createInt64Constant(value);
+                case TEXT:
+                    return OxlaConstant.createTextConstant(toString());
+                default:
+                    return null; // Impossible.
+            }
+        }
+
+        @Override
+        public int compareTo(OxlaConstant toType) {
+            if (toType instanceof OxlaInt32Constant) {
+                return Long.compare(this.value, ((OxlaInt32Constant) toType).value);
+            } else if (toType instanceof OxlaInt64Constant) {
+                return Long.compare(this.value, ((OxlaInt64Constant) toType).value);
+            } else if (toType instanceof OxlaFloat32Constant) {
+                return Float.compare(this.value, ((OxlaFloat32Constant) toType).value);
+            } else if (toType instanceof OxlaFloat64Constant) {
+                return Double.compare(this.value, ((OxlaFloat64Constant) toType).value);
+            }
+            throw new AssertionError(String.format("OxlaInt32Constant::compareTo not implemented for type: %s", toType.getClass()));
+        }
+    }
+
+    public static class OxlaInt64Constant extends OxlaConstant {
+        public final long value;
+
+        public OxlaInt64Constant(long value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public OxlaConstant tryCast(OxlaDataType toType) {
+            switch (toType) {
+                case BOOLEAN:
+                    return OxlaConstant.createBooleanConstant(value != 0);
+                case FLOAT32:
+                    return OxlaConstant.createFloat32Constant(value);
+                case FLOAT64:
+                    return OxlaConstant.createFloat64Constant(value);
+                case INT32:
+                    return OxlaConstant.createInt32Constant((int) value);
                 case INT64:
                     return this;
                 case TEXT:
@@ -346,14 +394,16 @@ public abstract class OxlaConstant implements OxlaExpression {
 
         @Override
         public int compareTo(OxlaConstant toType) {
-            if (toType instanceof OxlaIntegerConstant) {
-                return Long.compare(this.value, ((OxlaIntegerConstant) toType).value);
+            if (toType instanceof OxlaInt32Constant) {
+                return Long.compare(this.value, ((OxlaInt32Constant) toType).value);
+            } else if (toType instanceof OxlaInt64Constant) {
+                return Long.compare(this.value, ((OxlaInt64Constant) toType).value);
             } else if (toType instanceof OxlaFloat32Constant) {
                 return Float.compare(this.value, ((OxlaFloat32Constant) toType).value);
             } else if (toType instanceof OxlaFloat64Constant) {
                 return Double.compare(this.value, ((OxlaFloat64Constant) toType).value);
             }
-            throw new AssertionError(String.format("OxlaIntegerConstant::compareTo not implemented for type: %s", toType.getClass()));
+            throw new AssertionError(String.format("OxlaInt64Constant::compareTo not implemented for type: %s", toType.getClass()));
         }
     }
 

--- a/src/sqlancer/oxla/ast/OxlaConstant.java
+++ b/src/sqlancer/oxla/ast/OxlaConstant.java
@@ -223,9 +223,9 @@ public abstract class OxlaConstant implements OxlaExpression {
         @Override
         public String toString() {
             if (value == Float.POSITIVE_INFINITY) {
-                return "'infinity'";
+                return "'infinity'::FLOAT4";
             } else if (value == Float.NEGATIVE_INFINITY) {
-                return "'-infinity'";
+                return "'-infinity'::FLOAT4";
             }
             return String.valueOf(value);
         }
@@ -271,9 +271,9 @@ public abstract class OxlaConstant implements OxlaExpression {
         @Override
         public String toString() {
             if (value == Double.POSITIVE_INFINITY) {
-                return "'infinity'";
+                return "'infinity'::FLOAT8";
             } else if (value == Double.NEGATIVE_INFINITY) {
-                return "'-infinity'";
+                return "'-infinity'::FLOAT8";
             }
             return String.valueOf(value);
         }

--- a/src/sqlancer/oxla/ast/OxlaFunctionOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaFunctionOperation.java
@@ -86,7 +86,7 @@ public class OxlaFunctionOperation extends NewFunctionNode<OxlaExpression, OxlaF
             .addMultipleParamOverload("atan2d", new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT32}, OxlaDataType.FLOAT32, null)
             .addMultipleParamOverload("atan2d", new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64}, OxlaDataType.FLOAT64, null)
             .addOneParamMatchReturnOverloads("atan", OxlaDataType.FLOATING_POINT, null)
-            .addOneParamMatchReturnOverloads("atan2d", OxlaDataType.FLOATING_POINT, null)
+            .addOneParamMatchReturnOverloads("atand", OxlaDataType.FLOATING_POINT, null)
             .addNoParamOverload("pi", OxlaDataType.FLOAT64, (ignored) -> OxlaConstant.createFloat64Constant(Math.PI))
             .addOneParamMatchReturnOverloads("tan", OxlaDataType.FLOATING_POINT, null)
             .addOneParamMatchReturnOverloads("tand", OxlaDataType.FLOATING_POINT, null)

--- a/src/sqlancer/oxla/ast/OxlaFunctionOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaFunctionOperation.java
@@ -240,7 +240,7 @@ public class OxlaFunctionOperation extends NewFunctionNode<OxlaExpression, OxlaF
 
 
     public static final List<OxlaFunction> AGGREGATE = OxlaFunctionBuilder.create()
-            .addOneParamMatchReturnOverloads("sum", new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64, OxlaDataType.INT32, OxlaDataType.INT64, OxlaDataType.INTERVAL, OxlaDataType.TIME}, null)
+            .addOneParamOverloads("sum", new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64, OxlaDataType.INT32, OxlaDataType.INT64, OxlaDataType.INTERVAL, OxlaDataType.TIME}, new OxlaDataType[]{OxlaDataType.FLOAT64, OxlaDataType.FLOAT64, OxlaDataType.INT64, OxlaDataType.INT64, OxlaDataType.INTERVAL, OxlaDataType.TIME}, null)
             .addOneParamMatchReturnOverloads("min", new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.FLOAT32, OxlaDataType.FLOAT64, OxlaDataType.INT32, OxlaDataType.INT64, OxlaDataType.INTERVAL, OxlaDataType.TEXT, OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMP, OxlaDataType.TIME}, null)
             .addOneParamMatchReturnOverloads("max", new OxlaDataType[]{OxlaDataType.DATE, OxlaDataType.FLOAT32, OxlaDataType.FLOAT64, OxlaDataType.INT32, OxlaDataType.INT64, OxlaDataType.INTERVAL, OxlaDataType.TEXT, OxlaDataType.TIMESTAMPTZ, OxlaDataType.TIMESTAMP, OxlaDataType.TIME}, null)
             .addOneParamOverloads("avg", new OxlaDataType[]{OxlaDataType.FLOAT32, OxlaDataType.FLOAT64, OxlaDataType.INT32, OxlaDataType.INT64}, OxlaDataType.FLOAT64, null)
@@ -299,6 +299,14 @@ public class OxlaFunctionOperation extends NewFunctionNode<OxlaExpression, OxlaF
         public OxlaFunctionBuilder addOneParamOverloads(String textRepresentation, OxlaDataType[] types, OxlaDataType returnType, OxlaApplyFunction applyFunction) {
             for (OxlaDataType type : types) {
                 overloads.add(new OxlaFunction(textRepresentation, new OxlaTypeOverload(new OxlaDataType[]{type}, returnType), applyFunction));
+            }
+            return this;
+        }
+
+        public OxlaFunctionBuilder addOneParamOverloads(String textRepresentation, OxlaDataType[] types, OxlaDataType[] returnTypes, OxlaApplyFunction applyFunction) {
+            assert types.length == returnTypes.length;
+            for (int index = 0; index < types.length; ++index) {
+                overloads.add(new OxlaFunction(textRepresentation, new OxlaTypeOverload(new OxlaDataType[]{types[index]}, returnTypes[index]), applyFunction));
             }
             return this;
         }

--- a/src/sqlancer/oxla/ast/OxlaFunctionOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaFunctionOperation.java
@@ -337,8 +337,10 @@ public class OxlaFunctionOperation extends NewFunctionNode<OxlaExpression, OxlaF
             return OxlaConstant.createFloat32Constant(Math.abs(((OxlaConstant.OxlaFloat32Constant) constant).value));
         } else if (constant instanceof OxlaConstant.OxlaFloat64Constant) {
             return OxlaConstant.createFloat64Constant(Math.abs(((OxlaConstant.OxlaFloat64Constant) constant).value));
-        } else if (constant instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(Math.abs(((OxlaConstant.OxlaIntegerConstant) constant).value));
+        } else if (constant instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(Math.abs(((OxlaConstant.OxlaInt32Constant) constant).value));
+        } else if (constant instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant(Math.abs(((OxlaConstant.OxlaInt64Constant) constant).value));
         }
         throw new AssertionError(String.format("OxlaFunctionOperation::applyAbs failed: %s", constant.getClass()));
     }
@@ -382,8 +384,10 @@ public class OxlaFunctionOperation extends NewFunctionNode<OxlaExpression, OxlaF
     private static OxlaConstant applyBitPower(OxlaConstant[] constants) {
         final OxlaConstant left = constants[0];
         final OxlaConstant right = constants[1];
-        if (left instanceof OxlaConstant.OxlaIntegerConstant && right instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant((long) Math.pow(((OxlaConstant.OxlaIntegerConstant) left).value, ((OxlaConstant.OxlaIntegerConstant) right).value));
+        if (left instanceof OxlaConstant.OxlaInt32Constant && right instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant((int) Math.pow(((OxlaConstant.OxlaInt32Constant) left).value, ((OxlaConstant.OxlaInt32Constant) right).value));
+        } else if (left instanceof OxlaConstant.OxlaInt64Constant && right instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant((long) Math.pow(((OxlaConstant.OxlaInt64Constant) left).value, ((OxlaConstant.OxlaInt64Constant) right).value));
         } else if (left instanceof OxlaConstant.OxlaFloat32Constant && right instanceof OxlaConstant.OxlaFloat32Constant) {
             return OxlaConstant.createFloat32Constant((float) Math.pow(((OxlaConstant.OxlaFloat32Constant) left).value, ((OxlaConstant.OxlaFloat32Constant) right).value));
         } else if (left instanceof OxlaConstant.OxlaFloat64Constant && right instanceof OxlaConstant.OxlaFloat64Constant) {

--- a/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
+++ b/src/sqlancer/oxla/ast/OxlaUnaryPrefixOperation.java
@@ -82,8 +82,10 @@ public class OxlaUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<OxlaExp
             return OxlaConstant.createFloat32Constant(-((OxlaConstant.OxlaFloat32Constant) constant).value);
         } else if (constant instanceof OxlaConstant.OxlaFloat64Constant) {
             return OxlaConstant.createFloat64Constant(-((OxlaConstant.OxlaFloat64Constant) constant).value);
-        } else if (constant instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(-((OxlaConstant.OxlaIntegerConstant) constant).value);
+        } else if (constant instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(-((OxlaConstant.OxlaInt32Constant) constant).value);
+        } else if (constant instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant(-((OxlaConstant.OxlaInt64Constant) constant).value);
         }
         throw new AssertionError(String.format("OxlaUnaryPrefixOperation::applyMinus failed: %s", constant.getClass()));
     }
@@ -94,8 +96,10 @@ public class OxlaUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<OxlaExp
             return OxlaConstant.createFloat32Constant(Math.abs(((OxlaConstant.OxlaFloat32Constant) constant).value));
         } else if (constant instanceof OxlaConstant.OxlaFloat64Constant) {
             return OxlaConstant.createFloat64Constant(Math.abs(((OxlaConstant.OxlaFloat64Constant) constant).value));
-        } else if (constant instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(Math.abs(((OxlaConstant.OxlaIntegerConstant) constant).value));
+        } else if (constant instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(Math.abs(((OxlaConstant.OxlaInt32Constant) constant).value));
+        } else if (constant instanceof OxlaConstant.OxlaInt64Constant) {
+            return OxlaConstant.createInt64Constant(Math.abs(((OxlaConstant.OxlaInt64Constant) constant).value));
         }
         throw new AssertionError(String.format("OxlaUnaryPrefixOperation::applyAbs failed: %s", constant.getClass()));
     }
@@ -130,8 +134,10 @@ public class OxlaUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<OxlaExp
 
     private static OxlaConstant applyBitNot(OxlaConstant[] constants) {
         final OxlaConstant constant = constants[0];
-        if (constant instanceof OxlaConstant.OxlaIntegerConstant) {
-            return OxlaConstant.createInt64Constant(~((OxlaConstant.OxlaIntegerConstant) constant).value);
+        if (constant instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(~((OxlaConstant.OxlaInt32Constant) constant).value);
+        } else if (constant instanceof OxlaConstant.OxlaInt32Constant) {
+            return OxlaConstant.createInt32Constant(~((OxlaConstant.OxlaInt32Constant) constant).value);
         }
         throw new AssertionError(String.format("OxlaUnaryPrefixOperation::applyCbrt failed: %s", constant.getClass()));
     }

--- a/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
+++ b/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
@@ -46,6 +46,7 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
     private final OxlaGlobalState globalState;
     private List<OxlaTable> tables;
     private OxlaRowValue rowValue;
+    private boolean forceLiteralCasts = false;
 
     public OxlaExpressionGenerator(OxlaGlobalState globalState) {
         this.globalState = globalState;
@@ -56,14 +57,20 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
         return this;
     }
 
+    public OxlaExpressionGenerator forceLiteralCasts(boolean forceLiteralCasts) {
+        this.forceLiteralCasts = forceLiteralCasts;
+        return this;
+    }
+
     @Override
     public OxlaExpression generateConstant(OxlaDataType type) {
         if (Randomly.getBooleanWithSmallProbability()) {
-            return OxlaConstant.createNullConstant();
+            return forceLiteralCasts ? new OxlaCast(OxlaConstant.createNullConstant(), type)
+                    : OxlaConstant.createNullConstant();
         }
         // FIXME Imho, we should generate a random constant that is implicitly or explicitly cast-able to the wanted type.
         OxlaExpression expression = OxlaConstant.getRandomForType(globalState, type);
-        if (Randomly.getBooleanWithRatherLowProbability()) {
+        if (forceLiteralCasts || Randomly.getBooleanWithRatherLowProbability()) {
             return new OxlaCast(expression, type); // Explicit cast to self type.
         }
         return expression;

--- a/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
+++ b/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
@@ -186,8 +186,7 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
             OxlaExpressionGenerator joinGenerator = new OxlaExpressionGenerator(globalState).setColumns(columns);
             OxlaJoin.JoinType joinType = OxlaJoin.JoinType.getRandom();
             joinStatements.add(new OxlaJoin(leftTable, rightTable, joinType, joinType != OxlaJoin.JoinType.CROSS
-                    ? joinGenerator.generateExpression(OxlaDataType.BOOLEAN)
-                    : null));
+                    ? joinGenerator.generatePredicate() : null));
         }
         tables = tableReferences.stream().map(OxlaTableReference::getTable).collect(Collectors.toList());
         return joinStatements;

--- a/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
+++ b/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
@@ -294,8 +294,13 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
             );
         }
         if (OxlaBugs.bugOxla8350) {
-            validFunctions.removeIf(function -> function.textRepresentation.startsWith("pg_") &&
+            validFunctions.removeIf(function -> (function.textRepresentation.startsWith("pg_") ||
+                    function.textRepresentation.startsWith("has_")) &&
                     Arrays.stream(function.overload.inputTypes).anyMatch(type -> type == OxlaDataType.INT32 || type == OxlaDataType.INT64));
+        }
+
+        if (OxlaBugs.bugOxla8364) {
+            validFunctions.removeIf(function -> (function.textRepresentation.equalsIgnoreCase("timestamp_trunc")));
         }
 
         if (validFunctions.isEmpty()) {

--- a/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
+++ b/src/sqlancer/oxla/gen/OxlaExpressionGenerator.java
@@ -2,6 +2,7 @@ package sqlancer.oxla.gen;
 
 import sqlancer.Randomly;
 import sqlancer.common.gen.NoRECGenerator;
+import sqlancer.common.gen.TLPWhereGenerator;
 import sqlancer.common.gen.TypedExpressionGenerator;
 import sqlancer.common.schema.AbstractTables;
 import sqlancer.oxla.OxlaBugs;
@@ -20,7 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpression, OxlaColumn, OxlaDataType>
-        implements NoRECGenerator<OxlaSelect, OxlaJoin, OxlaExpression, OxlaTable, OxlaColumn> {
+        implements NoRECGenerator<OxlaSelect, OxlaJoin, OxlaExpression, OxlaTable, OxlaColumn>, TLPWhereGenerator<OxlaSelect, OxlaJoin, OxlaExpression, OxlaTable, OxlaColumn> {
     private enum ExpressionType {
         AGGREGATE_FUNCTION,
         BINARY_ARITHMETIC_OPERATOR,
@@ -195,6 +196,14 @@ public class OxlaExpressionGenerator extends TypedExpressionGenerator<OxlaExpres
     @Override
     public List<OxlaExpression> getTableRefs() {
         return tables.stream().map(OxlaTableReference::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<OxlaExpression> generateFetchColumns(boolean shouldCreateDummy) {
+        if (shouldCreateDummy || columns.isEmpty()) {
+            return List.of(new OxlaColumnReference(new OxlaColumn("*", null)));
+        }
+        return Randomly.nonEmptySubset(columns.stream().map(OxlaColumnReference::new).collect(Collectors.toList()));
     }
 
     @Override

--- a/src/sqlancer/oxla/oracle/OxlaFuzzer.java
+++ b/src/sqlancer/oxla/oracle/OxlaFuzzer.java
@@ -66,14 +66,14 @@ public class OxlaFuzzer implements TestOracle<OxlaGlobalState> {
 
         // WHERE
         if (Randomly.getBoolean()) {
-            select.setWhereClause(generator.generateExpression(OxlaDataType.BOOLEAN));
+            select.setWhereClause(generator.generatePredicate());
         }
         // GROUP BY
         if (Randomly.getBoolean()) {
             select.setGroupByClause(generator.generateExpressions(Randomly.smallNumber() + 1));
             // HAVING
             if (Randomly.getBoolean()) {
-                select.setHavingClause(generator.generateExpression(OxlaDataType.BOOLEAN));
+                select.setHavingClause(generator.generatePredicate());
             }
         }
         // ORDER BY

--- a/src/sqlancer/oxla/oracle/OxlaPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaPivotedQuerySynthesisOracle.java
@@ -8,11 +8,9 @@ import sqlancer.common.query.Query;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.oxla.OxlaExpectedValueVisitor;
 import sqlancer.oxla.OxlaGlobalState;
-import sqlancer.oxla.OxlaToStringVisitor;
 import sqlancer.oxla.ast.*;
 import sqlancer.oxla.gen.OxlaExpressionGenerator;
 import sqlancer.oxla.schema.OxlaColumn;
-import sqlancer.oxla.schema.OxlaDataType;
 import sqlancer.oxla.schema.OxlaRowValue;
 import sqlancer.oxla.schema.OxlaTables;
 

--- a/src/sqlancer/oxla/oracle/OxlaPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaPivotedQuerySynthesisOracle.java
@@ -84,7 +84,7 @@ public class OxlaPivotedQuerySynthesisOracle extends PivotedQuerySynthesisBase<O
             OxlaExpressionGenerator generator = new OxlaExpressionGenerator(globalState);
             generator.setColumns(fetchColumns);
             generator.setRowValue(pivotRow);
-            OxlaExpression expr = generator.generateExpression(OxlaDataType.BOOLEAN);
+            OxlaExpression expr = generator.generatePredicate();
             OxlaExpression result = null;
             if (expr.getExpectedValue() instanceof OxlaConstant.OxlaNullConstant) {
                 result = new OxlaUnaryPostfixOperation(expr, OxlaUnaryPostfixOperation.IS_NULL);
@@ -127,7 +127,7 @@ public class OxlaPivotedQuerySynthesisOracle extends PivotedQuerySynthesisBase<O
             select.setOffsetClause(OxlaConstant.createInt32Constant(0));
         }
 
-        return new SQLQueryAdapter(OxlaToStringVisitor.asString(select), errors);
+        return new SQLQueryAdapter(select.asString(), errors);
     }
 
     @Override

--- a/src/sqlancer/oxla/oracle/OxlaPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaPivotedQuerySynthesisOracle.java
@@ -3,9 +3,9 @@ package sqlancer.oxla.oracle;
 import sqlancer.Randomly;
 import sqlancer.SQLConnection;
 import sqlancer.common.oracle.PivotedQuerySynthesisBase;
+import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.oxla.OxlaCommon;
 import sqlancer.oxla.OxlaExpectedValueVisitor;
 import sqlancer.oxla.OxlaGlobalState;
 import sqlancer.oxla.OxlaToStringVisitor;
@@ -23,19 +23,9 @@ import java.util.stream.Collectors;
 public class OxlaPivotedQuerySynthesisOracle extends PivotedQuerySynthesisBase<OxlaGlobalState, OxlaRowValue, OxlaExpression, SQLConnection> {
     private List<OxlaColumn> fetchColumns;
 
-    public OxlaPivotedQuerySynthesisOracle(OxlaGlobalState globalState) {
+    public OxlaPivotedQuerySynthesisOracle(OxlaGlobalState globalState, ExpectedErrors errors) {
         super(globalState);
-        errors.addAll(OxlaCommon.SYNTAX_ERRORS);
-        errors.addAllRegexes(OxlaCommon.SYNTAX_REGEX_ERRORS);
-        errors.addAll(OxlaCommon.JOIN_ERRORS);
-        errors.addAllRegexes(OxlaCommon.JOIN_REGEX_ERRORS);
-        errors.addAll(OxlaCommon.GROUP_BY_ERRORS);
-        errors.addAllRegexes(OxlaCommon.GROUP_BY_REGEX_ERRORS);
-        errors.addAll(OxlaCommon.ORDER_BY_ERRORS);
-        errors.addAllRegexes(OxlaCommon.ORDER_BY_REGEX_ERRORS);
-        errors.addAll(OxlaCommon.EXPRESSION_ERRORS);
-        errors.addAllRegexes(OxlaCommon.EXPRESSION_REGEX_ERRORS);
-        errors.addAll(OxlaCommon.bugErrors());
+        this.errors.addAll(errors);
     }
 
     @Override

--- a/src/sqlancer/oxla/oracle/OxlaTLPAggregateOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPAggregateOracle.java
@@ -1,0 +1,130 @@
+package sqlancer.oxla.oracle;
+
+import com.yugabyte.util.PSQLException;
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLancerResultSet;
+import sqlancer.oxla.OxlaGlobalState;
+import sqlancer.oxla.OxlaToStringVisitor;
+import sqlancer.oxla.ast.*;
+import sqlancer.oxla.gen.OxlaExpressionGenerator;
+import sqlancer.oxla.schema.OxlaDataType;
+import sqlancer.oxla.schema.OxlaTables;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OxlaTLPAggregateOracle extends OxlaTLPBase {
+    private final static String FORMAT_STRING = "-- %s;\n-- result: %s";
+
+    public OxlaTLPAggregateOracle(OxlaGlobalState state, ExpectedErrors errors) {
+        super(state);
+        this.errors.addAll(errors);
+    }
+
+    @Override
+    public void check() throws Exception {
+        final OxlaTables targetTables = state.getSchema().getRandomTableNonEmptyTables();
+        generator = new OxlaExpressionGenerator(state).setColumns(targetTables.getColumns());
+        final OxlaSelect select = new OxlaSelect();
+        final OxlaFunctionOperation.OxlaFunction aggregateFunction = Randomly.fromList(OxlaFunctionOperation.AGGREGATE.stream().filter(p -> {
+            final String textRepresentation = p.textRepresentation;
+            return textRepresentation.equalsIgnoreCase("min") ||
+                    textRepresentation.equalsIgnoreCase("max") ||
+                    textRepresentation.equalsIgnoreCase("sum") ||
+                    textRepresentation.equalsIgnoreCase("count") ||
+                    textRepresentation.equalsIgnoreCase("bool_or") ||
+                    textRepresentation.equalsIgnoreCase("bool_and");
+        }).collect(Collectors.toList()));
+        final List<OxlaExpression> arguments = new ArrayList<>();
+        for (OxlaDataType type : aggregateFunction.overload.inputTypes) {
+            arguments.add(generator.generateExpression(type));
+        }
+        final OxlaFunctionOperation aggregate = new OxlaFunctionOperation(arguments, aggregateFunction);
+        select.setFetchColumns(List.of(aggregate));
+        select.setFromList(generator.getTableRefs());
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setJoinClauses(generator.getRandomJoinClauses());
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setOrderByClauses(generator.generateOrderBys());
+        }
+
+        final String originalQuery = OxlaToStringVisitor.asString(select);
+        final String firstResult = getAggregateResult(originalQuery);
+        final String metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
+        final String secondResult = getAggregateResult(metamorphicQuery);
+
+        String firstQueryString = String.format(FORMAT_STRING, originalQuery, firstResult);
+        String secondQueryString = String.format(FORMAT_STRING, metamorphicQuery, secondResult);
+        state.getState().getLocalState().log(String.format("%s\n%s", firstQueryString, secondQueryString));
+        if (firstResult == null && secondResult != null || firstResult != null && secondResult == null) {
+            throw new AssertionError(String.format("[%s] Miss-match between results:\n%s\n%s",
+                    state.getDatabaseName(),
+                    firstQueryString,
+                    secondQueryString));
+        }
+    }
+
+    private String createMetamorphicUnionQuery(OxlaSelect select, OxlaFunctionOperation aggregate, List<OxlaExpression> fromClauses) {
+        final OxlaExpression whereClause = generator.generateExpression(OxlaDataType.BOOLEAN);
+        final OxlaExpression negatedClause = new OxlaUnaryPrefixOperation(whereClause, OxlaUnaryPrefixOperation.NOT);
+        final OxlaExpression notNullClause = new OxlaUnaryPostfixOperation(whereClause, OxlaUnaryPostfixOperation.IS_NULL);
+
+        final List<OxlaExpression> mappedAggregate = List.of(new OxlaAlias(aggregate, "agg0"));
+        OxlaSelect leftSelect = getSelect(mappedAggregate, fromClauses, whereClause, select.getJoinClauses());
+        OxlaSelect middleSelect = getSelect(mappedAggregate, fromClauses, negatedClause, select.getJoinClauses());
+        OxlaSelect rightSelect = getSelect(mappedAggregate, fromClauses, notNullClause, select.getJoinClauses());
+
+        return String.format("SELECT %s FROM (%s UNION ALL %s UNION ALL %s) as result",
+                getOuterAggregateFunction(aggregate),
+                OxlaToStringVisitor.asString(leftSelect),
+                OxlaToStringVisitor.asString(middleSelect),
+                OxlaToStringVisitor.asString(rightSelect));
+    }
+
+    private OxlaSelect getSelect(List<OxlaExpression> aggregates, List<OxlaExpression> fromClauses, OxlaExpression whereClause, List<OxlaJoin> joinList) {
+        final OxlaSelect result = new OxlaSelect();
+        result.setFetchColumns(aggregates);
+        result.setFromList(fromClauses);
+        result.setWhereClause(whereClause);
+        result.setJoinClauses(joinList);
+        if (Randomly.getBooleanWithSmallProbability()) {
+            result.setGroupByExpressions(generator.generateExpressions(Randomly.smallNumber() + 1));
+        }
+        return result;
+    }
+
+    private String getOuterAggregateFunction(OxlaFunctionOperation aggregate) {
+        if (aggregate.getFunc().textRepresentation.equals("count")) {
+            return "sum(agg0)";
+        }
+        return String.format("%s(agg0)", aggregate.getFunc().toString());
+    }
+
+    private String getAggregateResult(String queryString) throws SQLException {
+        if (state.getOptions().logEachSelect()) {
+            state.getLogger().writeCurrent(queryString);
+            try {
+                state.getLogger().getCurrentFileWriter().flush();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        final SQLQueryAdapter query = new SQLQueryAdapter(queryString, errors);
+        try (final SQLancerResultSet result = query.executeAndGet(state)) {
+            if (result == null) {
+                throw new IgnoreMeException();
+            }
+            return result.next() ? result.getString(1) : null;
+        } catch (PSQLException e) {
+            throw new AssertionError(queryString, e);
+        }
+    }
+}

--- a/src/sqlancer/oxla/oracle/OxlaTLPAggregateOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPAggregateOracle.java
@@ -30,7 +30,7 @@ public class OxlaTLPAggregateOracle extends OxlaTLPBase {
     public void check() throws Exception {
         super.check();
         final OxlaTables targetTables = state.getSchema().getRandomTableNonEmptyTables();
-        generator = new OxlaExpressionGenerator(state).setColumns(targetTables.getColumns());
+        generator = new OxlaExpressionGenerator(state).setTablesAndColumns(targetTables).setColumns(targetTables.getColumns());
         final OxlaSelect select = new OxlaSelect();
         final OxlaFunctionOperation.OxlaFunction aggregateFunction = Randomly.fromList(OxlaFunctionOperation.AGGREGATE.stream().filter(p -> {
             final String textRepresentation = p.textRepresentation;

--- a/src/sqlancer/oxla/oracle/OxlaTLPAggregateOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPAggregateOracle.java
@@ -7,7 +7,6 @@ import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLancerResultSet;
 import sqlancer.oxla.OxlaGlobalState;
-import sqlancer.oxla.OxlaToStringVisitor;
 import sqlancer.oxla.ast.*;
 import sqlancer.oxla.gen.OxlaExpressionGenerator;
 import sqlancer.oxla.schema.OxlaDataType;

--- a/src/sqlancer/oxla/oracle/OxlaTLPBase.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPBase.java
@@ -18,13 +18,13 @@ public class OxlaTLPBase extends TernaryLogicPartitioningOracleBase<OxlaExpressi
 
     protected OxlaTLPBase(OxlaGlobalState state) {
         super(state);
-        generator = new OxlaExpressionGenerator(state).setColumns(targetTables.getColumns());
     }
 
     @Override
     public void check() throws Exception {
-        initializeTernaryPredicateVariants();
         targetTables = state.getSchema().getRandomTableNonEmptyTables();
+        generator = new OxlaExpressionGenerator(state).setTablesAndColumns(targetTables).setColumns(targetTables.getColumns());
+        initializeTernaryPredicateVariants();
         select = new OxlaSelect();
         select.setFetchColumns(generator.generateFetchColumns(Randomly.getBoolean()));
         select.setJoinClauses(generator.getRandomJoinClauses());

--- a/src/sqlancer/oxla/oracle/OxlaTLPBase.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPBase.java
@@ -23,7 +23,10 @@ public class OxlaTLPBase extends TernaryLogicPartitioningOracleBase<OxlaExpressi
     @Override
     public void check() throws Exception {
         targetTables = state.getSchema().getRandomTableNonEmptyTables();
-        generator = new OxlaExpressionGenerator(state).setTablesAndColumns(targetTables).setColumns(targetTables.getColumns());
+        generator = new OxlaExpressionGenerator(state)
+                .forceLiteralCasts(true)
+                .setTablesAndColumns(targetTables)
+                .setColumns(targetTables.getColumns());
         initializeTernaryPredicateVariants();
         select = new OxlaSelect();
         select.setFetchColumns(generator.generateFetchColumns(Randomly.getBoolean()));

--- a/src/sqlancer/oxla/oracle/OxlaTLPBase.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPBase.java
@@ -1,0 +1,39 @@
+package sqlancer.oxla.oracle;
+
+import sqlancer.Randomly;
+import sqlancer.common.gen.ExpressionGenerator;
+import sqlancer.common.oracle.TernaryLogicPartitioningOracleBase;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.oxla.OxlaGlobalState;
+import sqlancer.oxla.ast.OxlaExpression;
+import sqlancer.oxla.ast.OxlaSelect;
+import sqlancer.oxla.gen.OxlaExpressionGenerator;
+import sqlancer.oxla.schema.OxlaTables;
+
+public class OxlaTLPBase extends TernaryLogicPartitioningOracleBase<OxlaExpression, OxlaGlobalState>
+        implements TestOracle<OxlaGlobalState> {
+    protected OxlaExpressionGenerator generator;
+    protected OxlaTables targetTables;
+    protected OxlaSelect select;
+
+    protected OxlaTLPBase(OxlaGlobalState state) {
+        super(state);
+        generator = new OxlaExpressionGenerator(state).setColumns(targetTables.getColumns());
+    }
+
+    @Override
+    public void check() throws Exception {
+        initializeTernaryPredicateVariants();
+        targetTables = state.getSchema().getRandomTableNonEmptyTables();
+        select = new OxlaSelect();
+        select.setFetchColumns(generator.generateFetchColumns(Randomly.getBoolean()));
+        select.setJoinClauses(generator.getRandomJoinClauses());
+        select.setFromList(generator.getTableRefs());
+        select.setWhereClause(null);
+    }
+
+    @Override
+    protected ExpressionGenerator<OxlaExpression> getGen() {
+        return generator;
+    }
+}

--- a/src/sqlancer/oxla/oracle/OxlaTLPDistinctOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPDistinctOracle.java
@@ -1,0 +1,9 @@
+package sqlancer.oxla.oracle;
+
+import sqlancer.oxla.OxlaGlobalState;
+
+public class OxlaTLPDistinctOracle extends OxlaTLPBase {
+    public OxlaTLPDistinctOracle(OxlaGlobalState state) {
+        super(state);
+    }
+}

--- a/src/sqlancer/oxla/oracle/OxlaTLPDistinctOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPDistinctOracle.java
@@ -1,9 +1,47 @@
 package sqlancer.oxla.oracle;
 
+import sqlancer.ComparatorHelper;
+import sqlancer.common.query.ExpectedErrors;
 import sqlancer.oxla.OxlaGlobalState;
+import sqlancer.oxla.OxlaToStringVisitor;
+import sqlancer.oxla.ast.OxlaSelect;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class OxlaTLPDistinctOracle extends OxlaTLPBase {
-    public OxlaTLPDistinctOracle(OxlaGlobalState state) {
+    private String originalQueryString;
+
+    public OxlaTLPDistinctOracle(OxlaGlobalState state, ExpectedErrors errors) {
         super(state);
+        this.errors.addAll(errors);
+    }
+
+    @Override
+    public void check() throws Exception {
+        super.check();
+        select.type = OxlaSelect.SelectType.DISTINCT;
+        select.setWhereClause(null);
+
+        originalQueryString = select.asString();
+        final List<String> originalResult = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
+
+        select.setWhereClause(predicate);
+        final String trueQuery = select.asString();
+
+        select.setWhereClause(negatedPredicate);
+        final String falseQuery = select.asString();
+
+        select.setWhereClause(isNullPredicate);
+        final String isNullQuery = select.asString();
+
+        final List<String> combinedString = new ArrayList<>();
+        final List<String> combinedResult = ComparatorHelper.getCombinedResultSetNoDuplicates(trueQuery, falseQuery, isNullQuery, combinedString, true, state, errors);
+        ComparatorHelper.assumeResultSetsAreEqual(originalResult, combinedResult, originalQueryString, combinedString, state);
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return originalQueryString;
     }
 }

--- a/src/sqlancer/oxla/oracle/OxlaTLPDistinctOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPDistinctOracle.java
@@ -3,7 +3,6 @@ package sqlancer.oxla.oracle;
 import sqlancer.ComparatorHelper;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.oxla.OxlaGlobalState;
-import sqlancer.oxla.OxlaToStringVisitor;
 import sqlancer.oxla.ast.OxlaSelect;
 
 import java.util.ArrayList;

--- a/src/sqlancer/oxla/oracle/OxlaTLPGroupByOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPGroupByOracle.java
@@ -1,0 +1,9 @@
+package sqlancer.oxla.oracle;
+
+import sqlancer.oxla.OxlaGlobalState;
+
+public class OxlaTLPGroupByOracle extends OxlaTLPBase {
+    public OxlaTLPGroupByOracle(OxlaGlobalState state) {
+        super(state);
+    }
+}

--- a/src/sqlancer/oxla/oracle/OxlaTLPGroupByOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPGroupByOracle.java
@@ -1,9 +1,46 @@
 package sqlancer.oxla.oracle;
 
+import sqlancer.ComparatorHelper;
+import sqlancer.common.query.ExpectedErrors;
 import sqlancer.oxla.OxlaGlobalState;
+import sqlancer.oxla.OxlaToStringVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class OxlaTLPGroupByOracle extends OxlaTLPBase {
-    public OxlaTLPGroupByOracle(OxlaGlobalState state) {
+    private String originalQueryString;
+
+    public OxlaTLPGroupByOracle(OxlaGlobalState state, ExpectedErrors errors) {
         super(state);
+        this.errors.addAll(errors);
+    }
+
+    @Override
+    public void check() throws Exception {
+        super.check();
+        select.setGroupByClause(select.getFetchColumns());
+        select.setWhereClause(null);
+
+        originalQueryString = select.asString();
+        final List<String> originalResult = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
+
+        select.setWhereClause(predicate);
+        final String trueQuery = select.asString();
+
+        select.setWhereClause(negatedPredicate);
+        final String falseQuery = select.asString();
+
+        select.setWhereClause(isNullPredicate);
+        final String isNullQuery = select.asString();
+
+        final List<String> combinedString = new ArrayList<>();
+        final List<String> combinedResult = ComparatorHelper.getCombinedResultSetNoDuplicates(trueQuery, falseQuery, isNullQuery, combinedString, true, state, errors);
+        ComparatorHelper.assumeResultSetsAreEqual(originalResult, combinedResult, originalQueryString, combinedString, state);
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return originalQueryString;
     }
 }

--- a/src/sqlancer/oxla/oracle/OxlaTLPGroupByOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPGroupByOracle.java
@@ -3,7 +3,6 @@ package sqlancer.oxla.oracle;
 import sqlancer.ComparatorHelper;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.oxla.OxlaGlobalState;
-import sqlancer.oxla.OxlaToStringVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/sqlancer/oxla/oracle/OxlaTLPHavingOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPHavingOracle.java
@@ -1,9 +1,46 @@
 package sqlancer.oxla.oracle;
 
+import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
 import sqlancer.oxla.OxlaGlobalState;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class OxlaTLPHavingOracle extends OxlaTLPBase {
-    public OxlaTLPHavingOracle(OxlaGlobalState state) {
+    public OxlaTLPHavingOracle(OxlaGlobalState state, ExpectedErrors errors) {
         super(state);
+        this.errors.addAll(errors);
+    }
+
+    @Override
+    public void check() throws Exception {
+        super.check();
+        if (Randomly.getBoolean()) {
+            select.setWhereClause(generator.generatePredicate());
+        }
+        select.setGroupByExpressions(generator.generateExpressions(Randomly.smallNumber() + 1));
+        select.setHavingClause(null);
+
+        final String originalQuery = select.asString();
+        final List<String> originalResult = ComparatorHelper.getResultSetFirstColumnAsString(originalQuery, errors, state);
+
+        final boolean generateOrderBy = Randomly.getBoolean();
+        if (generateOrderBy) {
+            select.setOrderByClauses(generator.generateOrderBys());
+        }
+        select.setWhereClause(predicate);
+        final String trueQuery = select.asString();
+
+        select.setWhereClause(negatedPredicate);
+        final String falseQuery = select.asString();
+
+        select.setWhereClause(isNullPredicate);
+        final String isNullQuery = select.asString();
+
+        final List<String> combinedString = new ArrayList<>();
+        final List<String> combinedResult = ComparatorHelper.getCombinedResultSetNoDuplicates(trueQuery, falseQuery, isNullQuery, combinedString, true, state, errors);
+        ComparatorHelper.assumeResultSetsAreEqual(originalResult, combinedResult, originalQuery, combinedString, state);
     }
 }

--- a/src/sqlancer/oxla/oracle/OxlaTLPHavingOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPHavingOracle.java
@@ -20,16 +20,16 @@ public class OxlaTLPHavingOracle extends OxlaTLPBase {
         if (Randomly.getBoolean()) {
             select.setWhereClause(generator.generatePredicate());
         }
+        final boolean generateOrderBy = Randomly.getBoolean();
+        if (generateOrderBy) {
+            select.setOrderByClauses(generator.generateOrderBys());
+        }
         select.setGroupByExpressions(generator.generateExpressions(Randomly.smallNumber() + 1));
         select.setHavingClause(null);
 
         final String originalQuery = select.asString();
         final List<String> originalResult = ComparatorHelper.getResultSetFirstColumnAsString(originalQuery, errors, state);
 
-        final boolean generateOrderBy = Randomly.getBoolean();
-        if (generateOrderBy) {
-            select.setOrderByClauses(generator.generateOrderBys());
-        }
         select.setHavingClause(predicate);
         final String trueQuery = select.asString();
 

--- a/src/sqlancer/oxla/oracle/OxlaTLPHavingOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPHavingOracle.java
@@ -30,13 +30,13 @@ public class OxlaTLPHavingOracle extends OxlaTLPBase {
         if (generateOrderBy) {
             select.setOrderByClauses(generator.generateOrderBys());
         }
-        select.setWhereClause(predicate);
+        select.setHavingClause(predicate);
         final String trueQuery = select.asString();
 
-        select.setWhereClause(negatedPredicate);
+        select.setHavingClause(negatedPredicate);
         final String falseQuery = select.asString();
 
-        select.setWhereClause(isNullPredicate);
+        select.setHavingClause(isNullPredicate);
         final String isNullQuery = select.asString();
 
         final List<String> combinedString = new ArrayList<>();

--- a/src/sqlancer/oxla/oracle/OxlaTLPHavingOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPHavingOracle.java
@@ -1,0 +1,9 @@
+package sqlancer.oxla.oracle;
+
+import sqlancer.oxla.OxlaGlobalState;
+
+public class OxlaTLPHavingOracle extends OxlaTLPBase {
+    public OxlaTLPHavingOracle(OxlaGlobalState state) {
+        super(state);
+    }
+}

--- a/src/sqlancer/oxla/oracle/OxlaTLPHavingOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPHavingOracle.java
@@ -40,7 +40,7 @@ public class OxlaTLPHavingOracle extends OxlaTLPBase {
         final String isNullQuery = select.asString();
 
         final List<String> combinedString = new ArrayList<>();
-        final List<String> combinedResult = ComparatorHelper.getCombinedResultSetNoDuplicates(trueQuery, falseQuery, isNullQuery, combinedString, true, state, errors);
+        final List<String> combinedResult = ComparatorHelper.getCombinedResultSetNoDuplicates(trueQuery, falseQuery, isNullQuery, combinedString, !generateOrderBy, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(originalResult, combinedResult, originalQuery, combinedString, state);
     }
 }

--- a/src/sqlancer/oxla/oracle/OxlaTLPWhereExtendedOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPWhereExtendedOracle.java
@@ -1,0 +1,9 @@
+package sqlancer.oxla.oracle;
+
+import sqlancer.oxla.OxlaGlobalState;
+
+public class OxlaTLPWhereExtendedOracle extends OxlaTLPBase {
+    public OxlaTLPWhereExtendedOracle(OxlaGlobalState state) {
+        super(state);
+    }
+}

--- a/src/sqlancer/oxla/oracle/OxlaTLPWhereExtendedOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPWhereExtendedOracle.java
@@ -10,11 +10,15 @@ import sqlancer.oxla.ast.OxlaOperator;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public class OxlaTLPWhereExtendedOracle extends OxlaTLPBase {
     private String originalQueryString;
     private OxlaExpression originalPredicate;
+
+    private static final OxlaOperator andOperator = OxlaBinaryOperation.LOGIC
+            .stream()
+            .filter(o -> o.textRepresentation.equalsIgnoreCase("and"))
+            .findFirst().orElse(null);
 
     public OxlaTLPWhereExtendedOracle(OxlaGlobalState state, ExpectedErrors errors) {
         super(state);
@@ -53,11 +57,7 @@ public class OxlaTLPWhereExtendedOracle extends OxlaTLPBase {
     }
 
     private OxlaExpression combinedPredicate(OxlaExpression expr) {
-        final Optional<OxlaOperator> andOperator = OxlaBinaryOperation.LOGIC
-                .stream()
-                .filter(o -> o.textRepresentation.equalsIgnoreCase("and"))
-                .findFirst();
-        assert andOperator.isPresent();
-        return new OxlaBinaryOperation(originalPredicate, expr, andOperator.get());
+        assert andOperator != null;
+        return new OxlaBinaryOperation(originalPredicate, expr, andOperator);
     }
 }

--- a/src/sqlancer/oxla/oracle/OxlaTLPWhereExtendedOracle.java
+++ b/src/sqlancer/oxla/oracle/OxlaTLPWhereExtendedOracle.java
@@ -1,9 +1,63 @@
 package sqlancer.oxla.oracle;
 
+import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
 import sqlancer.oxla.OxlaGlobalState;
+import sqlancer.oxla.ast.OxlaBinaryOperation;
+import sqlancer.oxla.ast.OxlaExpression;
+import sqlancer.oxla.ast.OxlaOperator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 public class OxlaTLPWhereExtendedOracle extends OxlaTLPBase {
-    public OxlaTLPWhereExtendedOracle(OxlaGlobalState state) {
+    private String originalQueryString;
+    private OxlaExpression originalPredicate;
+
+    public OxlaTLPWhereExtendedOracle(OxlaGlobalState state, ExpectedErrors errors) {
         super(state);
+        this.errors.addAll(errors);
+    }
+
+    @Override
+    public void check() throws Exception {
+        super.check();
+        originalPredicate = generatePredicate();
+        select.setWhereClause(originalPredicate);
+        originalQueryString = select.asString();
+        final List<String> originalResult = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
+
+        final boolean generateOrderBy = Randomly.getBoolean();
+        if (generateOrderBy) {
+            select.setOrderByClauses(generator.generateOrderBys());
+        }
+        select.setWhereClause(combinedPredicate(predicate));
+        final String trueQuery = select.asString();
+
+        select.setWhereClause(combinedPredicate(negatedPredicate));
+        final String falseQuery = select.asString();
+
+        select.setWhereClause(combinedPredicate(isNullPredicate));
+        final String isNullQuery = select.asString();
+
+        final List<String> combinedString = new ArrayList<>();
+        final List<String> combinedResult = ComparatorHelper.getCombinedResultSetNoDuplicates(trueQuery, falseQuery, isNullQuery, combinedString, !generateOrderBy, state, errors);
+        ComparatorHelper.assumeResultSetsAreEqual(originalResult, combinedResult, originalQueryString, combinedString, state);
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return originalQueryString;
+    }
+
+    private OxlaExpression combinedPredicate(OxlaExpression expr) {
+        final Optional<OxlaOperator> andOperator = OxlaBinaryOperation.LOGIC
+                .stream()
+                .filter(o -> o.textRepresentation.equalsIgnoreCase("and"))
+                .findFirst();
+        assert andOperator.isPresent();
+        return new OxlaBinaryOperation(originalPredicate, expr, andOperator.get());
     }
 }

--- a/src/sqlancer/oxla/schema/OxlaDataType.java
+++ b/src/sqlancer/oxla/schema/OxlaDataType.java
@@ -4,6 +4,7 @@ import sqlancer.Randomly;
 
 import java.util.Arrays;
 
+// TODO OXLA-8233 Add `decimal` and `numeric` types after they are supported natively in Oxla.
 public enum OxlaDataType {
     BOOLEAN, DATE, FLOAT32, FLOAT64, INT32, INT64, INTERVAL, JSON, TEXT, TIME, TIMESTAMP, TIMESTAMPTZ;
 
@@ -39,12 +40,10 @@ public enum OxlaDataType {
             case "real":
             case "float4":
                 return FLOAT32;
-            case "decimal":
             case "double precision":
             case "double":
             case "float":
             case "float8":
-            case "numeric":
                 return FLOAT64;
             case "int":
             case "int4":
@@ -88,7 +87,7 @@ public enum OxlaDataType {
             case FLOAT32:
                 return Randomly.fromOptions("real", "float4");
             case FLOAT64:
-                return Randomly.fromOptions("decimal", "double precision", "double", "float", "float8", "numeric");
+                return Randomly.fromOptions("double precision", "double", "float", "float8");
             case INT32:
                 return Randomly.fromOptions("int", "int4", "integer");
             case INT64:


### PR DESCRIPTION
Implements the following `Ternarly Logic Partitioning (TLP)` oracles:
* Aggregate
* Distinct
* Group By
* Having
* Where
* Where (Extended)

Adds more expected errors in `OxlaCommon`.
Adds `bugOxla????` switch for handling problematic query.
Adds method for merging `ExpectedErrors` with each other.
Fixes concatenation of queries in `ComparatorHelper`.
Fixes stringification of `+Infinity`/`-Inifnity` floating point lierals.
Fixes signatures of some function and operator overloads.
Splits `OxlaIntegerConstant` into `OxlaInt32Constant` and `OxlaInt64Constant`.
Replaces `generateExpression(Boolean)` with more explicit (and correct) `generatePredicate` (where possible).
Removed aliases for `decimal` and `numeric` as they caused major false-positives.

Bug(s) caught by this PR:
https://oxla.atlassian.net/browse/OXLA-8362 - This one could only be caught by the `TLP` oracle :tada: 
https://oxla.atlassian.net/browse/OXLA-8364
https://oxla.atlassian.net/browse/OXLA-8374
https://oxla.atlassian.net/browse/OXLA-8378